### PR TITLE
Document setup and add dataset tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -400,3 +400,5 @@ yarn-error.log*
 # Build outputs
 dist/
 build/
+# GGUF models
+models/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,8 +4,17 @@
   - `X-API-Key`
   - optional `X-Reasoning: think|no_think|auto`
 - Ensure a GGUF model is mounted at `/models` (compose does it).
+- For local tests download `SmolLM-135M-Instruct.Q4_K_S.gguf` into `./models`:
+  ```bash
+  export HF_TOKEN="<il tuo token>"
+  huggingface-cli download MaziyarPanahi/SmolLM-135M-Instruct-GGUF \
+    SmolLM-135M-Instruct.Q4_K_S.gguf \
+    --local-dir ./models --token "$HF_TOKEN"
+  export LLM__ModelPath="$(pwd)/models/SmolLM-135M-Instruct.Q4_K_S.gguf"
+  ```
 - Output is always **valid JSON** due to **GBNF grammar** at inference, then validated against **Extraction Profiles**.
 
 Prompts:
 - The server injects `/think` or `/no_think` automatically based on header/config.
 - Do not add explanations; responses must be pure JSON.
+- Dataset samples live under `/dataset`; run `LLM__ModelPath=./models/SmolLM-135M-Instruct.Q4_K_S.gguf MSBUILDTERMINALLOGGER=false dotnet test` and `python -m pytest` to validate them.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # docflow-ai-net
 
-.NET 9 API + Python FastAPI sidecar for OCR→Markdown (MarkItDown+Tesseract) and LLM extraction (LLamaSharp + Qwen3 GGUF).
+.NET 9 API + Python FastAPI sidecar for OCR→Markdown (MarkItDown+Tesseract) and LLM extraction (LLamaSharp + GGUF).
 
 ## Highlights
 - Clean layering (Domain / Application / Infrastructure / API)
@@ -18,7 +18,26 @@ cd deployment
 docker compose up --build
 # API: http://localhost:5214  |  MarkItDown: http://localhost:8000
 ```
-Modello GGUF: metti il file in `./models` (es. `qwen3-1_5-instruct-q4_0.gguf`).
+Modello GGUF: metti il file in `./models` (es. `SmolLM-135M-Instruct.Q4_K_S.gguf`).
+
+### Download del modello GGUF
+Scarica il modello leggero per i test in `./models` usando un token Hugging Face:
+```bash
+export HF_TOKEN="<il tuo token>"
+huggingface-cli download MaziyarPanahi/SmolLM-135M-Instruct-GGUF \
+  SmolLM-135M-Instruct.Q4_K_S.gguf \
+  --local-dir ./models --token "$HF_TOKEN"
+export LLM__ModelPath="$(pwd)/models/SmolLM-135M-Instruct.Q4_K_S.gguf"
+```
+
+### Dataset e test
+Nel repo è presente un dataset di esempio sotto `./dataset`.
+Per eseguire i test (inclusi quelli sul dataset):
+```bash
+export MSBUILDTERMINALLOGGER=false
+dotnet test
+python -m pytest
+```
 
 ## All-in-one Docker (API + Python nello stesso container)
 ```bash

--- a/src/DocflowAi.Net.Api/Controllers/ProcessController.cs
+++ b/src/DocflowAi.Net.Api/Controllers/ProcessController.cs
@@ -4,8 +4,11 @@ namespace DocflowAi.Net.Api.Controllers;
 public sealed class ProcessController : ControllerBase {
     private readonly IProcessingOrchestrator _orchestrator; private readonly IReasoningModeAccessor _modeAccessor;
     public ProcessController(IProcessingOrchestrator orchestrator, IReasoningModeAccessor modeAccessor) { _orchestrator = orchestrator; _modeAccessor = modeAccessor; }
-    [HttpPost] [RequestSizeLimit(20_000_000)] [ProducesResponseType(typeof(DocumentAnalysisResult), StatusCodes.Status200OK)]
-    public async Task<IActionResult> Process([FromForm] IFormFile file, CancellationToken ct) {
+    [HttpPost]
+    [RequestSizeLimit(20_000_000)]
+    [Consumes("multipart/form-data")]
+    [ProducesResponseType(typeof(DocumentAnalysisResult), StatusCodes.Status200OK)]
+    public async Task<IActionResult> Process(IFormFile file, CancellationToken ct) {
         if (file is null) return BadRequest("file is required");
         if (Request.Headers.TryGetValue("X-Reasoning", out var mode)) {
             var v = mode.ToString().Trim().ToLowerInvariant();

--- a/src/DocflowAi.Net.Api/DocflowAi.Net.Api.csproj
+++ b/src/DocflowAi.Net.Api/DocflowAi.Net.Api.csproj
@@ -19,8 +19,8 @@
     <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.2.0" />
-    <PackageReference Include="Hellang.Middleware.ProblemDetails" Version="6.8.1" />
+      <PackageReference Include="Hellang.Middleware.ProblemDetails" Version="6.5.1" />
     <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.10.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.0" />
   </ItemGroup>
 </Project>

--- a/src/DocflowAi.Net.Api/Program.cs
+++ b/src/DocflowAi.Net.Api/Program.cs
@@ -49,7 +49,7 @@ builder.Services.AddHttpClient<IMarkitdownClient, MarkitdownClient>()
     .AddPolicyHandler((sp,_) => HttpPolicies.GetTimeoutPolicy(sp.GetRequiredService<Microsoft.Extensions.Options.IOptions<ServicesOptions>>()));
 
 builder.Services.AddScoped<IReasoningModeAccessor, ReasoningModeAccessor>();
-builder.Services.AddSingleton<ILlamaExtractor, LlamaExtractor>();
+builder.Services.AddScoped<ILlamaExtractor, LlamaExtractor>();
 builder.Services.AddScoped<IProcessingOrchestrator, ProcessingOrchestrator>();
 
 builder.Services.AddHealthChecks();
@@ -66,5 +66,7 @@ app.UseSwaggerUI();
 app.MapHealthChecks("/health");
 app.MapControllers();
 app.Run();
+
+public partial class Program { }
 
 public static class ApiKeyDefaults { public const string SchemeName = "ApiKey"; }

--- a/src/DocflowAi.Net.Api/Security/ApiKeyAuthenticationHandler.cs
+++ b/src/DocflowAi.Net.Api/Security/ApiKeyAuthenticationHandler.cs
@@ -4,7 +4,7 @@ public sealed class ApiKeyAuthenticationHandler : AuthenticationHandler<Authenti
     private readonly ApiKeyOptions _opts;
     public ApiKeyAuthenticationHandler(IOptionsMonitor<AuthenticationSchemeOptions> options, ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock, IOptions<ApiKeyOptions> apiOpts) : base(options, logger, encoder, clock) { _opts = apiOpts.Value; }
     protected override Task<AuthenticateResult> HandleAuthenticateAsync() {
-        if (!Request.Headers.TryGetValue(_opts.HeaderName, out var provided)) return Task.FromResult(AuthenticateResult.Fail("Missing API Key header."));
+        if (!Request.Headers.TryGetValue(_opts.HeaderName, out var provided)) return Task.FromResult(AuthenticateResult.NoResult());
         if (_opts.Keys.Length == 0) return Task.FromResult(AuthenticateResult.Fail("No API keys configured."));
         if (!_opts.Keys.Contains(provided.ToString())) return Task.FromResult(AuthenticateResult.Fail("Invalid API key."));
         var claims = new[] { new Claim(ClaimTypes.NameIdentifier, "api-key-user") };

--- a/src/DocflowAi.Net.Application/DocflowAi.Net.Application.csproj
+++ b/src/DocflowAi.Net.Application/DocflowAi.Net.Application.csproj
@@ -7,5 +7,6 @@
   <ItemGroup>
     <ProjectReference Include="..\DocflowAi.Net.Domain\DocflowAi.Net.Domain.csproj" />
     <PackageReference Include="FluentValidation" Version="11.10.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
   </ItemGroup>
 </Project>

--- a/src/DocflowAi.Net.Infrastructure/DocflowAi.Net.Infrastructure.csproj
+++ b/src/DocflowAi.Net.Infrastructure/DocflowAi.Net.Infrastructure.csproj
@@ -8,11 +8,12 @@
     <ProjectReference Include="..\DocflowAi.Net.Application\DocflowAi.Net.Application.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.10.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.0" />
     <PackageReference Include="Serilog" Version="3.1.1" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
-    <PackageReference Include="LLamaSharp" Version="0.12.0" />
-    <PackageReference Include="LLamaSharp.Backend.Cpu" Version="0.12.0" />
+    <PackageReference Include="LLamaSharp" Version="0.9.1" />
+    <PackageReference Include="LLamaSharp.Backend.Cpu" Version="0.9.1" />
+    <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Grammars\json.gbnf">

--- a/tests/DocflowAi.Net.Tests.Integration/DocflowAi.Net.Tests.Integration.csproj
+++ b/tests/DocflowAi.Net.Tests.Integration/DocflowAi.Net.Tests.Integration.csproj
@@ -1,5 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup><TargetFramework>net9.0</TargetFramework><IsPackable>false</IsPackable><Nullable>enable</Nullable></PropertyGroup>
+  <PropertyGroup><TargetFramework>net9.0</TargetFramework><IsPackable>false</IsPackable><Nullable>enable</Nullable><ImplicitUsings>enable</ImplicitUsings></PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\DocflowAi.Net.Api\DocflowAi.Net.Api.csproj" />
     <PackageReference Include="xunit" Version="2.9.0" />

--- a/tests/DocflowAi.Net.Tests.Integration/Usings.cs
+++ b/tests/DocflowAi.Net.Tests.Integration/Usings.cs
@@ -1,0 +1,2 @@
+global using Xunit;
+global using System.Threading.Tasks;

--- a/tests/DocflowAi.Net.Tests.Unit/DatasetTests.cs
+++ b/tests/DocflowAi.Net.Tests.Unit/DatasetTests.cs
@@ -1,0 +1,30 @@
+using System;
+using System.IO;
+using FluentAssertions;
+using Xunit;
+
+namespace DocflowAi.Net.Tests.Unit;
+
+public class DatasetTests
+{
+    private static readonly string DatasetPath = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", "dataset");
+
+    [Fact]
+    public void DatasetFilesExist()
+    {
+        File.Exists(Path.Combine(DatasetPath, "prompt.txt")).Should().BeTrue();
+        File.Exists(Path.Combine(DatasetPath, "sample_invoice.pdf")).Should().BeTrue();
+        File.Exists(Path.Combine(DatasetPath, "sample_invoice.png")).Should().BeTrue();
+        File.Exists(Path.Combine(DatasetPath, "valori_campi.txt")).Should().BeTrue();
+    }
+
+    [Fact]
+    public void PromptContainsExpectedFields()
+    {
+        var text = File.ReadAllText(Path.Combine(DatasetPath, "prompt.txt"));
+        text.Should().Contain("company_name");
+        text.Should().Contain("document_type");
+        text.Should().Contain("invoice_number");
+        text.Should().Contain("invoice_date");
+    }
+}

--- a/tests/DocflowAi.Net.Tests.Unit/DocflowAi.Net.Tests.Unit.csproj
+++ b/tests/DocflowAi.Net.Tests.Unit/DocflowAi.Net.Tests.Unit.csproj
@@ -1,9 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup><TargetFramework>net9.0</TargetFramework><IsPackable>false</IsPackable><Nullable>enable</Nullable></PropertyGroup>
+  <PropertyGroup><TargetFramework>net9.0</TargetFramework><IsPackable>false</IsPackable><Nullable>enable</Nullable><ImplicitUsings>enable</ImplicitUsings></PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\DocflowAi.Net.Application\DocflowAi.Net.Application.csproj" />
     <ProjectReference Include="..\..\src\DocflowAi.Net.Domain\DocflowAi.Net.Domain.csproj" />
     <ProjectReference Include="..\..\src\DocflowAi.Net.Infrastructure\DocflowAi.Net.Infrastructure.csproj" />
+    <ProjectReference Include="..\..\src\DocflowAi.Net.Api\DocflowAi.Net.Api.csproj" />
     <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageReference Include="Moq" Version="4.20.72" />

--- a/tests/DocflowAi.Net.Tests.Unit/ProcessingOrchestratorTests.cs
+++ b/tests/DocflowAi.Net.Tests.Unit/ProcessingOrchestratorTests.cs
@@ -4,6 +4,7 @@ using DocflowAi.Net.Domain.Extraction;
 using DocflowAi.Net.Infrastructure.Orchestration;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
 using Moq;
 namespace DocflowAi.Net.Tests.Unit;
 public class ProcessingOrchestratorTests {

--- a/tests/DocflowAi.Net.Tests.Unit/Usings.cs
+++ b/tests/DocflowAi.Net.Tests.Unit/Usings.cs
@@ -1,0 +1,2 @@
+global using Xunit;
+global using System.Threading.Tasks;


### PR DESCRIPTION
## Summary
- document lightweight SmolLM model download and test execution
- fix API key auth and swagger file upload handling
- update Llama extractor and test projects for .NET 9

## Testing
- `MSBUILDTERMINALLOGGER=false LLM__ModelPath=/workspace/docflow-ai-net/models/SmolLM-135M-Instruct.Q4_K_S.gguf dotnet test`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b0f673690832595fd9858dd5598c8