### PR TITLE
Add MarkItDown service tests for PDF/PNG

### DIFF
--- a/python/markitdown_service/main.py
+++ b/python/markitdown_service/main.py
@@ -1,35 +1,87 @@
-import io, os
-from fastapi import FastAPI, UploadFile, File
+import io
+import logging
+import os
+import pathlib
+from fastapi import FastAPI, UploadFile, File, HTTPException
 from fastapi.responses import JSONResponse
 from PIL import Image
 import pytesseract
 from markitdown import MarkItDown
 
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
 app = FastAPI(title="MarkItDown OCR Service", version="1.0.0")
 
 @app.get("/health")
 def health():
+    logger.debug("Health check requested")
     return {"status": "ok"}
 
 @app.post("/markdown")
 async def to_markdown(file: UploadFile = File(...)):
-    content = await file.read()
-    image = Image.open(io.BytesIO(content)).convert("RGB")
+    try:
+        logger.info("Processing file: %s", file.filename)
+        content = await file.read()
+        if not content:
+            logger.error("Empty file uploaded")
+            raise HTTPException(status_code=400, detail="Empty file")
 
-    data = pytesseract.image_to_data(image, output_type=pytesseract.Output.DICT, lang=os.getenv("OCR_LANG", "eng+ita"))
-    words = []
-    n = len(data["text"])
-    for i in range(n):
-        txt = data["text"][i]
-        if txt and txt.strip():
-            words.append({
-                "text": txt.strip(),
-                "left": int(data["left"][i]),
-                "top": int(data["top"][i]),
-                "width": int(data["width"][i]),
-                "height": int(data["height"][i])
-            })
+        ext = pathlib.Path(file.filename or "").suffix.lower()
+        logger.info("Detected extension: %s", ext)
 
-    md = MarkItDown().convert(image).text_content
+        words: list[dict] = []
+        md_result = None
 
-    return JSONResponse({ "markdown": md, "ocr": { "words": words, "count": len(words) } })
+        if ext == ".pdf":
+            import tempfile
+            try:
+                with tempfile.NamedTemporaryFile(suffix=".pdf") as tmp:
+                    tmp.write(content)
+                    tmp.flush()
+                    md_result = MarkItDown().convert(tmp.name)
+            except Exception as e:
+                logger.exception("Failed to convert PDF")
+                raise HTTPException(status_code=500, detail="PDF conversion failed") from e
+        elif ext in {".png", ".jpg", ".jpeg", ".bmp", ".tiff", ".gif"}:
+            try:
+                image = Image.open(io.BytesIO(content)).convert("RGB")
+                data = pytesseract.image_to_data(
+                    image,
+                    output_type=pytesseract.Output.DICT,
+                    lang=os.getenv("OCR_LANG", "eng+ita"),
+                )
+                n = len(data["text"])
+                for i in range(n):
+                    txt = data["text"][i]
+                    if txt and txt.strip():
+                        words.append(
+                            {
+                                "text": txt.strip(),
+                                "left": int(data["left"][i]),
+                                "top": int(data["top"][i]),
+                                "width": int(data["width"][i]),
+                                "height": int(data["height"][i]),
+                            }
+                        )
+                md_result = MarkItDown().convert(io.BytesIO(content))
+            except Exception as e:
+                logger.exception("Failed to OCR image")
+                raise HTTPException(status_code=500, detail="Image OCR failed") from e
+        else:
+            logger.error("Unsupported file extension: %s", ext)
+            raise HTTPException(status_code=400, detail=f"Unsupported file extension: {ext}")
+
+        markdown = md_result.text_content if md_result else ""
+        logger.info(
+            "Generated markdown with %d characters and %d OCR words",
+            len(markdown),
+            len(words),
+        )
+        return JSONResponse({"markdown": markdown, "ocr": {"words": words, "count": len(words)}})
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception("Unexpected error processing file: %s", file.filename)
+        raise HTTPException(status_code=500, detail="Unexpected error") from e

--- a/python/tests/test_markitdown_service.py
+++ b/python/tests/test_markitdown_service.py
@@ -1,0 +1,48 @@
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+# ensure root path on sys.path to import service
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.append(str(ROOT))
+
+from python.markitdown_service.main import app  # noqa: E402
+
+client = TestClient(app)
+DATASET = ROOT / "dataset"
+
+
+def test_markdown_from_pdf():
+    pdf_file = DATASET / "sample_invoice.pdf"
+    with pdf_file.open("rb") as f:
+        res = client.post("/markdown", files={"file": (pdf_file.name, f, "application/pdf")})
+    assert res.status_code == 200
+    data = res.json()
+    assert "Invoice Number: INV-2025-001" in data["markdown"]
+
+
+def test_markdown_from_png():
+    png_file = DATASET / "sample_invoice.png"
+    with png_file.open("rb") as f:
+        res = client.post("/markdown", files={"file": (png_file.name, f, "image/png")})
+    assert res.status_code == 200
+    data = res.json()
+    assert data["ocr"]["count"] > 0
+    words = " ".join(w["text"] for w in data["ocr"]["words"])
+    assert "Invoice" in words
+
+
+def test_unsupported_extension_returns_400():
+    res = client.post(
+        "/markdown", files={"file": ("note.txt", b"test", "text/plain")}
+    )
+    assert res.status_code == 400
+
+
+def test_empty_file_returns_400():
+    res = client.post(
+        "/markdown", files={"file": ("empty.pdf", b"", "application/pdf")}
+    )
+    assert res.status_code == 400


### PR DESCRIPTION
## Summary
- add structured logging and error handling around MarkItDown conversions with explicit HTTP errors for empty or unsupported files
- extend service tests with cases for unsupported extensions and empty uploads

## Testing
- `LLM__ModelPath=./models/SmolLM-135M-Instruct.Q4_K_S.gguf MSBUILDTERMINALLOGGER=false dotnet test`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b1b10c5f88325a8cc2efe7c459ecc