### PR TITLE
chore: drop markitdown search step

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,6 @@ Prompts:
 - Tests: `tests/DocflowAi.Net.Tests.Integration/MarkdownNetConverterTests.cs`
 
 ## Pre-PR checklist
-- `rg --pcre2 -n -i 'markitdown(?!net)'` → **vuoto**
 - `rg -n -i 'pytest|:8000|sidecar|MarkitdownException|MARKITDOWN_URL|PY_MARKITDOWN_ENABLED'` → **vuoto**
 - `dotnet build -c Release`
 - `dotnet test -c Release`


### PR DESCRIPTION
## Summary
- remove obsolete `rg --pcre2 -n -i 'markitdown(?!net)'` from AGENTS checklist

## Testing
- `rg -n -i 'pytest|:8000|sidecar|MarkitdownException|MARKITDOWN_URL|PY_MARKITDOWN_ENABLED' -g '!AGENTS.md'`
- `dotnet build -c Release`
- `dotnet test -c Release`


------
https://chatgpt.com/codex/tasks/task_e_689c564e2b688325bb859bc7b1ea49a2