### PR TITLE
Add pervasive logging across processing pipeline

### DIFF
--- a/src/DocflowAi.Net.BBoxResolver/DocflowAi.Net.BBoxResolver.csproj
+++ b/src/DocflowAi.Net.BBoxResolver/DocflowAi.Net.BBoxResolver.csproj
@@ -8,5 +8,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.0" />
     <PackageReference Include="Serilog" Version="4.3.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.8" />
   </ItemGroup>
 </Project>

--- a/src/DocflowAi.Net.BBoxResolver/LegacyBBoxResolver.cs
+++ b/src/DocflowAi.Net.BBoxResolver/LegacyBBoxResolver.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 
 namespace DocflowAi.Net.BBoxResolver;
 
@@ -8,16 +9,23 @@ namespace DocflowAi.Net.BBoxResolver;
 public sealed class LegacyBBoxResolver : IBBoxResolver
 {
     private readonly BBoxOptions _options;
+    private readonly ILogger<LegacyBBoxResolver> _logger;
 
-    public LegacyBBoxResolver(Microsoft.Extensions.Options.IOptions<BBoxOptions> options) => _options = options.Value;
+    public LegacyBBoxResolver(Microsoft.Extensions.Options.IOptions<BBoxOptions> options, ILogger<LegacyBBoxResolver> logger)
+    {
+        _options = options.Value;
+        _logger = logger;
+    }
 
     public Task<IReadOnlyList<BBoxResolveResult>> ResolveAsync(DocumentIndex index, IReadOnlyList<ExtractedField> fields, CancellationToken ct = default)
     {
+        _logger.LogInformation("Legacy resolver processing {Count} fields", fields.Count);
         var results = new ConcurrentBag<BBoxResolveResult>();
         var finder = new CandidateFinder(index);
         var refiner = new CandidateRefiner(index, _options);
         Parallel.ForEach(fields, new ParallelOptions { CancellationToken = ct }, field =>
         {
+            _logger.LogDebug("Resolving field {FieldName} via Legacy", field.Key);
             var candidates = finder.Find(field.Value ?? string.Empty, _options.MaxCandidates);
             var best = refiner.Refine(field.Key, field.Value ?? string.Empty, candidates);
             var confidence = field.Confidence;
@@ -26,9 +34,16 @@ public sealed class LegacyBBoxResolver : IBBoxResolver
             {
                 spans = new[] { best };
                 confidence = 0.6 * best.Score + 0.4 * field.Confidence;
+                _logger.LogDebug("Field {FieldName} resolved with score {Score}", field.Key, best.Score);
+            }
+            else
+            {
+                _logger.LogDebug("Field {FieldName} unresolved", field.Key);
             }
             results.Add(new BBoxResolveResult(field.Key, field.Value, confidence, spans));
         });
-        return Task.FromResult((IReadOnlyList<BBoxResolveResult>)results.OrderBy(r => r.FieldName).ToList());
+        var ordered = results.OrderBy(r => r.FieldName).ToList();
+        _logger.LogInformation("Legacy resolver produced {Count} results", ordered.Count);
+        return Task.FromResult((IReadOnlyList<BBoxResolveResult>)ordered);
     }
 }

--- a/src/DocflowAi.Net.BBoxResolver/PlainTextViewBuilder.cs
+++ b/src/DocflowAi.Net.BBoxResolver/PlainTextViewBuilder.cs
@@ -1,12 +1,18 @@
 using System.Text;
+using Microsoft.Extensions.Logging;
 
 namespace DocflowAi.Net.BBoxResolver;
 
 /// <summary>Builds a plain text view and word spans for offset mapping.</summary>
 public sealed class PlainTextViewBuilder
 {
+    private readonly ILogger<PlainTextViewBuilder> _logger;
+
+    public PlainTextViewBuilder(ILogger<PlainTextViewBuilder> logger) => _logger = logger;
+
     public (string textView, List<(int page, int wordIdx, int start, int len)> wordSpans) Build(DocumentIndex index)
     {
+        _logger.LogDebug("Building plain text view for {PageCount} pages", index.Pages.Length);
         var sb = new StringBuilder();
         var spans = new List<(int, int, int, int)>();
         var start = 0;
@@ -27,7 +33,9 @@ public sealed class PlainTextViewBuilder
                 start += text.Length;
             }
         }
-        return (sb.ToString(), spans);
+        var textView = sb.ToString();
+        _logger.LogDebug("Built plain text view of length {Length}", textView.Length);
+        return (textView, spans);
     }
 }
 

--- a/src/DocflowAi.Net.Infrastructure/Markdown/MarkdownNetConverter.cs
+++ b/src/DocflowAi.Net.Infrastructure/Markdown/MarkdownNetConverter.cs
@@ -37,6 +37,7 @@ public sealed class MarkdownNetConverter : IMarkdownConverter
         var tmp = Path.GetTempFileName();
         try
         {
+            _logger.LogDebug("Copying input stream to temp file {TempFile}", tmp);
             await CopyWithRetryAsync(input, tmp, ct);
             _logger.LogDebug("Starting MarkItDownNet conversion for {Mime} into {TempFile}", mime, tmp);
             var options = new MkdnOptions { NormalizeMarkdown = opts.NormalizeMarkdown };
@@ -55,6 +56,7 @@ public sealed class MarkdownNetConverter : IMarkdownConverter
                 return new Box(w.Page, x, y, width, height, w.BBox.X, w.BBox.Y, w.BBox.Width, w.BBox.Height, w.Text);
             }).ToList();
 
+            _logger.LogInformation("MarkItDownNet produced {PageCount} pages", pages.Count);
             _logger.LogDebug("Converted to markdown with {Length} chars and {Boxes} boxes", res.Markdown.Length, boxes.Count);
             return new MarkdownResult(res.Markdown, pages, boxes);
         }

--- a/src/DocflowAi.Net.Infrastructure/Orchestration/ProcessingOrchestrator.cs
+++ b/src/DocflowAi.Net.Infrastructure/Orchestration/ProcessingOrchestrator.cs
@@ -50,12 +50,15 @@ public sealed class ProcessingOrchestrator : IProcessingOrchestrator
 
         await using var stream = file.OpenReadStream();
 
+        _logger.LogDebug("Opened read stream for {FileName}", file.FileName);
+
         var debugDir = Environment.GetEnvironmentVariable("DEBUG_DIR");
         if (!string.IsNullOrWhiteSpace(debugDir))
         {
             Directory.CreateDirectory(debugDir);
             File.WriteAllText(Path.Combine(debugDir, "fields.txt"), JsonSerializer.Serialize(fields));
             File.WriteAllText(Path.Combine(debugDir, "prompt.txt"), prompt);
+            _logger.LogDebug("Wrote debug artifacts to {Dir}", debugDir);
         }
 
         try
@@ -63,21 +66,36 @@ public sealed class ProcessingOrchestrator : IProcessingOrchestrator
             MarkdownResult mdResult;
             var options = new MarkdownOptions();
             if (file.ContentType == "application/pdf" || file.FileName.EndsWith(".pdf", StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.LogInformation("Converting PDF for {FileName}", file.FileName);
                 mdResult = await _converter.ConvertPdfAsync(stream, options);
+            }
             else if (file.ContentType.StartsWith("image/") || new[]{".png",".jpg",".jpeg"}.Any(e => file.FileName.EndsWith(e, StringComparison.OrdinalIgnoreCase)))
+            {
+                _logger.LogInformation("Converting image for {FileName}", file.FileName);
                 mdResult = await _converter.ConvertImageAsync(stream, options);
+            }
             else
+            {
+                _logger.LogWarning("Unsupported content type {ContentType} for {FileName}", file.ContentType, file.FileName);
                 throw new ArgumentException($"Unsupported content type: {file.ContentType}");
+            }
+
+            _logger.LogInformation("Markdown conversion produced {Chars} chars and {Boxes} boxes", mdResult.Markdown.Length, mdResult.Boxes.Count);
 
             if (!string.IsNullOrWhiteSpace(debugDir))
             {
                 File.WriteAllText(Path.Combine(debugDir, "markdown.txt"), mdResult.Markdown);
             }
 
+            _logger.LogInformation("Running LLM extraction for {FileName}", file.FileName);
             var result = await _llama.ExtractAsync(mdResult.Markdown, templateName, prompt, fields, ct);
+            _logger.LogInformation("LLM extraction returned {FieldCount} fields", result.Fields.Count);
+            _logger.LogDebug("Building document index for {FileName}", file.FileName);
             var pagesIn = mdResult.Pages.Select(p => new DocumentIndexBuilder.SourcePage(p.Number, (float)p.Width, (float)p.Height)).ToList();
             var wordsIn = mdResult.Boxes.Select(b => new DocumentIndexBuilder.SourceWord(b.Page, b.Text, (float)b.XNorm, (float)b.YNorm, (float)b.WidthNorm, (float)b.HeightNorm, false)).ToList();
             var index = DocumentIndexBuilder.Build(pagesIn, wordsIn);
+            _logger.LogInformation("Resolving bounding boxes for {FieldCount} fields", result.Fields.Count);
             var resolved = await _resolver.ResolveAsync(index, result.Fields, ct);
             var enrichedFields = resolved.Select(r => new ExtractedField(r.FieldName, r.Value, r.Confidence, r.Spans, r.Pointer)).ToList();
             var enriched = new DocumentAnalysisResult(result.DocumentType, enrichedFields, result.Language, result.Notes);

--- a/tests/DocflowAi.Net.BBoxResolver.Tests/BBoxResolverTests.cs
+++ b/tests/DocflowAi.Net.BBoxResolver.Tests/BBoxResolverTests.cs
@@ -1,6 +1,7 @@
 using DocflowAi.Net.BBoxResolver;
 using FluentAssertions;
 using Xunit;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace DocflowAi.Net.BBoxResolver.Tests;
 
@@ -23,7 +24,7 @@ public class BBoxResolverTests
     {
         var index = BuildIndex(("Hello",0f), ("World",10f));
         var field = new ExtractedField("greet", "hello world", 0.5);
-        var resolver = new TokenFirstBBoxResolver(Microsoft.Extensions.Options.Options.Create(new BBoxOptions()));
+        var resolver = new TokenFirstBBoxResolver(Microsoft.Extensions.Options.Options.Create(new BBoxOptions()), NullLogger<TokenFirstBBoxResolver>.Instance);
         var res = await resolver.ResolveAsync(index, new[]{field});
         res[0].Spans.Should().NotBeEmpty();
         res[0].Spans[0].Text.Should().Be("Hello World");
@@ -34,7 +35,7 @@ public class BBoxResolverTests
     {
         var index = BuildIndex(("1,234.56",0f));
         var field = new ExtractedField("num", "1.234,56", 0.5);
-        var resolver = new TokenFirstBBoxResolver(Microsoft.Extensions.Options.Options.Create(new BBoxOptions()));
+        var resolver = new TokenFirstBBoxResolver(Microsoft.Extensions.Options.Options.Create(new BBoxOptions()), NullLogger<TokenFirstBBoxResolver>.Instance);
         var res = await resolver.ResolveAsync(index, new[]{field});
         res[0].Spans.Should().NotBeEmpty();
     }
@@ -44,7 +45,7 @@ public class BBoxResolverTests
     {
         var index = BuildIndex(("ACME",0f), ("S.p.A.",10f));
         var field = new ExtractedField("company", "ACME SPA", 0.5);
-        var resolver = new TokenFirstBBoxResolver(Microsoft.Extensions.Options.Options.Create(new BBoxOptions()));
+        var resolver = new TokenFirstBBoxResolver(Microsoft.Extensions.Options.Options.Create(new BBoxOptions()), NullLogger<TokenFirstBBoxResolver>.Instance);
         var res = await resolver.ResolveAsync(index, new[]{field});
         res[0].Spans.Should().NotBeEmpty();
         res[0].Spans[0].WordIndices.Should().BeEquivalentTo(new[]{0,1});
@@ -55,7 +56,7 @@ public class BBoxResolverTests
     {
         var index = BuildIndex(("ABCDEFG",0f));
         var field = new ExtractedField("code", "ABCDXYG", 0.5);
-        var resolver = new TokenFirstBBoxResolver(Microsoft.Extensions.Options.Options.Create(new BBoxOptions()));
+        var resolver = new TokenFirstBBoxResolver(Microsoft.Extensions.Options.Options.Create(new BBoxOptions()), NullLogger<TokenFirstBBoxResolver>.Instance);
         var res = await resolver.ResolveAsync(index, new[]{field});
         res[0].Spans.Should().NotBeEmpty();
     }
@@ -65,7 +66,7 @@ public class BBoxResolverTests
     {
         var index = BuildIndex(("Code",0f), ("123",10f), ("123",20f));
         var field = new ExtractedField("Code", "123", 0.5);
-        var resolver = new TokenFirstBBoxResolver(Microsoft.Extensions.Options.Options.Create(new BBoxOptions()));
+        var resolver = new TokenFirstBBoxResolver(Microsoft.Extensions.Options.Options.Create(new BBoxOptions()), NullLogger<TokenFirstBBoxResolver>.Instance);
         var res = await resolver.ResolveAsync(index, new[]{field});
         res[0].Spans.Should().NotBeEmpty();
         res[0].Spans[0].WordIndices[0].Should().Be(1);
@@ -80,7 +81,7 @@ public class BBoxResolverTests
             words.Add(new DocumentIndexBuilder.SourceWord(1,$"w{i}", i/6000f,0,0.1f,0.1f,false));
         var index = DocumentIndexBuilder.Build(pages, words);
         var fields = Enumerable.Range(0,20).Select(i=> new ExtractedField($"f{i}", $"w{i*3}",0.5)).ToList();
-        var resolver = new TokenFirstBBoxResolver(Microsoft.Extensions.Options.Options.Create(new BBoxOptions()));
+        var resolver = new TokenFirstBBoxResolver(Microsoft.Extensions.Options.Options.Create(new BBoxOptions()), NullLogger<TokenFirstBBoxResolver>.Instance);
         var sw = System.Diagnostics.Stopwatch.StartNew();
         var res = await resolver.ResolveAsync(index, fields);
         sw.Stop();

--- a/tests/DocflowAi.Net.BBoxResolver.Tests/DocflowAi.Net.BBoxResolver.Tests.csproj
+++ b/tests/DocflowAi.Net.BBoxResolver.Tests/DocflowAi.Net.BBoxResolver.Tests.csproj
@@ -15,5 +15,6 @@
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="8.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.8" />
   </ItemGroup>
 </Project>

--- a/tests/DocflowAi.Net.Tests.Unit/DocflowAi.Net.Tests.Unit.csproj
+++ b/tests/DocflowAi.Net.Tests.Unit/DocflowAi.Net.Tests.Unit.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="FluentAssertions" Version="8.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.8" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\DocflowAi.Net.BBoxResolver\DocflowAi.Net.BBoxResolver.csproj" />

--- a/tests/DocflowAi.Net.Tests.Unit/ProcessControllerHeaderTests.cs
+++ b/tests/DocflowAi.Net.Tests.Unit/ProcessControllerHeaderTests.cs
@@ -9,6 +9,7 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace DocflowAi.Net.Tests.Unit;
 
@@ -30,7 +31,7 @@ public class ProcessControllerHeaderTests
         var accessor = new Mock<IReasoningModeAccessor>();
         accessor.SetupProperty(a => a.Mode, ReasoningMode.Auto);
 
-        var controller = new ProcessController(orchestrator.Object, accessor.Object)
+        var controller = new ProcessController(orchestrator.Object, accessor.Object, NullLogger<ProcessController>.Instance)
         {
             ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
         };


### PR DESCRIPTION
## Summary
- add request-level logging in `ProcessController`
- trace each processing stage in `ProcessingOrchestrator`, `LlamaExtractor`, and markdown conversion
- instrument BBox resolution components with detailed logs and update tests

## Testing
- `rg -n -i 'pytest|:8000|sidecar|MarkitdownException|MARKITDOWN_URL|PY_MARKITDOWN_ENABLED' --glob '!AGENTS.md'`
- `dotnet build -c Release`
- `dotnet test -c Release`


------
https://chatgpt.com/codex/tasks/task_e_689caa36cbf88325b5134626c2d02349