### PR TITLE
Add endpoint to switch LLM model at runtime

### DIFF
--- a/src/DocflowAi.Net.Api/Controllers/ModelController.cs
+++ b/src/DocflowAi.Net.Api/Controllers/ModelController.cs
@@ -1,0 +1,27 @@
+using DocflowAi.Net.Api.Models;
+using DocflowAi.Net.Application.Abstractions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DocflowAi.Net.Api.Controllers;
+
+[ApiController]
+[Route("api/v1/model")]
+[Authorize(AuthenticationSchemes = ApiKeyDefaults.SchemeName)]
+public sealed class ModelController : ControllerBase
+{
+    private readonly ILlmModelService _service;
+
+    public ModelController(ILlmModelService service)
+    {
+        _service = service;
+    }
+
+    [HttpPost("switch")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public async Task<IActionResult> Switch([FromBody] SwitchModelRequest request, CancellationToken ct)
+    {
+        await _service.SwitchModelAsync(request.HfKey, request.ModelRepo, request.ModelFile, request.ContextSize, ct);
+        return Ok();
+    }
+}

--- a/src/DocflowAi.Net.Api/Controllers/ModelController.cs
+++ b/src/DocflowAi.Net.Api/Controllers/ModelController.cs
@@ -24,4 +24,11 @@ public sealed class ModelController : ControllerBase
         await _service.SwitchModelAsync(request.HfKey, request.ModelRepo, request.ModelFile, request.ContextSize, ct);
         return Ok();
     }
+
+    [HttpGet("status")]
+    [ProducesResponseType(typeof(ModelDownloadStatus), StatusCodes.Status200OK)]
+    public ActionResult<ModelDownloadStatus> Status()
+    {
+        return Ok(_service.GetStatus());
+    }
 }

--- a/src/DocflowAi.Net.Api/Models/SwitchModelRequest.cs
+++ b/src/DocflowAi.Net.Api/Models/SwitchModelRequest.cs
@@ -1,0 +1,18 @@
+namespace DocflowAi.Net.Api.Models;
+
+using System.ComponentModel.DataAnnotations;
+
+public sealed class SwitchModelRequest
+{
+    [Required]
+    public string HfKey { get; init; } = string.Empty;
+
+    [Required]
+    public string ModelRepo { get; init; } = string.Empty;
+
+    [Required]
+    public string ModelFile { get; init; } = string.Empty;
+
+    [Range(1, int.MaxValue)]
+    public int ContextSize { get; init; }
+}

--- a/src/DocflowAi.Net.Api/Program.cs
+++ b/src/DocflowAi.Net.Api/Program.cs
@@ -59,6 +59,7 @@ builder.Services.AddSingleton<TokenFirstBBoxResolver>();
 builder.Services.AddSingleton<PlainTextViewBuilder>();
 builder.Services.AddSingleton<IPointerResolver, PointerResolver>();
 builder.Services.AddSingleton<IResolverOrchestrator, ResolverOrchestrator>();
+builder.Services.AddHttpClient<ILlmModelService, LlmModelService>();
 
 builder.Services.AddHealthChecks();
 

--- a/src/DocflowAi.Net.Application/Abstractions/ILlmModelService.cs
+++ b/src/DocflowAi.Net.Application/Abstractions/ILlmModelService.cs
@@ -1,0 +1,6 @@
+namespace DocflowAi.Net.Application.Abstractions;
+
+public interface ILlmModelService
+{
+    Task SwitchModelAsync(string hfKey, string modelRepo, string modelFile, int contextSize, CancellationToken ct);
+}

--- a/src/DocflowAi.Net.Application/Abstractions/ILlmModelService.cs
+++ b/src/DocflowAi.Net.Application/Abstractions/ILlmModelService.cs
@@ -3,4 +3,6 @@ namespace DocflowAi.Net.Application.Abstractions;
 public interface ILlmModelService
 {
     Task SwitchModelAsync(string hfKey, string modelRepo, string modelFile, int contextSize, CancellationToken ct);
+
+    ModelDownloadStatus GetStatus();
 }

--- a/src/DocflowAi.Net.Application/Abstractions/ModelDownloadStatus.cs
+++ b/src/DocflowAi.Net.Application/Abstractions/ModelDownloadStatus.cs
@@ -1,0 +1,3 @@
+namespace DocflowAi.Net.Application.Abstractions;
+
+public sealed record ModelDownloadStatus(bool Completed, double Percentage);

--- a/src/DocflowAi.Net.Infrastructure/Llm/LlmModelService.cs
+++ b/src/DocflowAi.Net.Infrastructure/Llm/LlmModelService.cs
@@ -1,0 +1,49 @@
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using DocflowAi.Net.Application.Abstractions;
+using DocflowAi.Net.Application.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace DocflowAi.Net.Infrastructure.Llm;
+
+public sealed class LlmModelService : ILlmModelService
+{
+    private readonly HttpClient _httpClient;
+    private readonly LlmOptions _options;
+    private readonly ILogger<LlmModelService> _logger;
+
+    public LlmModelService(HttpClient httpClient, IOptions<LlmOptions> options, ILogger<LlmModelService> logger)
+    {
+        _httpClient = httpClient;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public async Task SwitchModelAsync(string hfKey, string modelRepo, string modelFile, int contextSize, CancellationToken ct)
+    {
+        var modelsDir = Environment.GetEnvironmentVariable("MODELS_DIR") ?? Path.Combine(AppContext.BaseDirectory, "models");
+        Directory.CreateDirectory(modelsDir);
+        var dest = Path.Combine(modelsDir, modelFile);
+        if (!File.Exists(dest))
+        {
+            var url = $"https://huggingface.co/{modelRepo}/resolve/main/{modelFile}";
+            using var req = new HttpRequestMessage(HttpMethod.Get, url);
+            req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", hfKey);
+            using var resp = await _httpClient.SendAsync(req, ct);
+            if (!resp.IsSuccessStatusCode)
+            {
+                if (resp.StatusCode == HttpStatusCode.NotFound)
+                    throw new FileNotFoundException($"Model {modelRepo}/{modelFile} not found on HuggingFace");
+                resp.EnsureSuccessStatusCode();
+            }
+            await using var fs = File.Create(dest);
+            await resp.Content.CopyToAsync(fs, ct);
+        }
+        _options.ModelPath = dest;
+        _options.ContextTokens = contextSize;
+        _logger.LogInformation("LLM model switched to {ModelPath}", dest);
+    }
+}

--- a/src/DocflowAi.Net.Infrastructure/Llm/LlmModelService.cs
+++ b/src/DocflowAi.Net.Infrastructure/Llm/LlmModelService.cs
@@ -2,6 +2,7 @@ using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Threading;
 using DocflowAi.Net.Application.Abstractions;
 using DocflowAi.Net.Application.Configuration;
 using Microsoft.Extensions.Logging;
@@ -15,6 +16,10 @@ public sealed class LlmModelService : ILlmModelService
     private readonly LlmOptions _options;
     private readonly ILogger<LlmModelService> _logger;
 
+    private Task? _downloadTask;
+    private long _totalBytes;
+    private long _downloadedBytes;
+
     public LlmModelService(HttpClient httpClient, IOptions<LlmOptions> options, ILogger<LlmModelService> logger)
     {
         _httpClient = httpClient;
@@ -27,23 +32,67 @@ public sealed class LlmModelService : ILlmModelService
         var modelsDir = Environment.GetEnvironmentVariable("MODELS_DIR") ?? Path.Combine(AppContext.BaseDirectory, "models");
         Directory.CreateDirectory(modelsDir);
         var dest = Path.Combine(modelsDir, modelFile);
-        if (!File.Exists(dest))
+        if (File.Exists(dest))
         {
-            var url = $"https://huggingface.co/{modelRepo}/resolve/main/{modelFile}";
+            _options.ModelPath = dest;
+            _options.ContextTokens = contextSize;
+            _logger.LogInformation("LLM model switched to {ModelPath}", dest);
+            _downloadTask = null;
+            _totalBytes = 0;
+            _downloadedBytes = 0;
+            return;
+        }
+
+        var url = $"https://huggingface.co/{modelRepo}/resolve/main/{modelFile}";
+
+        using var head = new HttpRequestMessage(HttpMethod.Head, url);
+        head.Headers.Authorization = new AuthenticationHeaderValue("Bearer", hfKey);
+        using var headResp = await _httpClient.SendAsync(head, ct);
+        if (headResp.StatusCode == HttpStatusCode.NotFound)
+            throw new FileNotFoundException($"Model {modelRepo}/{modelFile} not found on HuggingFace");
+        headResp.EnsureSuccessStatusCode();
+        _totalBytes = headResp.Content.Headers.ContentLength ?? 0;
+        _downloadedBytes = 0;
+
+        _downloadTask = DownloadAndSwitchAsync(url, hfKey, dest, contextSize, ct);
+    }
+
+    private async Task DownloadAndSwitchAsync(string url, string hfKey, string dest, int contextSize, CancellationToken ct)
+    {
+        try
+        {
             using var req = new HttpRequestMessage(HttpMethod.Get, url);
             req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", hfKey);
-            using var resp = await _httpClient.SendAsync(req, ct);
-            if (!resp.IsSuccessStatusCode)
-            {
-                if (resp.StatusCode == HttpStatusCode.NotFound)
-                    throw new FileNotFoundException($"Model {modelRepo}/{modelFile} not found on HuggingFace");
-                resp.EnsureSuccessStatusCode();
-            }
+            using var resp = await _httpClient.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, ct);
+            resp.EnsureSuccessStatusCode();
             await using var fs = File.Create(dest);
-            await resp.Content.CopyToAsync(fs, ct);
+            await using var stream = await resp.Content.ReadAsStreamAsync(ct);
+            var buffer = new byte[81920];
+            int read;
+            while ((read = await stream.ReadAsync(buffer, 0, buffer.Length, ct)) > 0)
+            {
+                await fs.WriteAsync(buffer.AsMemory(0, read), ct);
+                Interlocked.Add(ref _downloadedBytes, read);
+            }
+
+            _options.ModelPath = dest;
+            _options.ContextTokens = contextSize;
+            _logger.LogInformation("LLM model switched to {ModelPath}", dest);
         }
-        _options.ModelPath = dest;
-        _options.ContextTokens = contextSize;
-        _logger.LogInformation("LLM model switched to {ModelPath}", dest);
+        catch (Exception ex) when (ex is not FileNotFoundException)
+        {
+            _logger.LogError(ex, "Error downloading model {Url}", url);
+        }
+    }
+
+    public ModelDownloadStatus GetStatus()
+    {
+        var task = _downloadTask;
+        if (task == null)
+            return new ModelDownloadStatus(true, 100);
+        var completed = task.IsCompleted;
+        var pct = _totalBytes > 0 ? (double)Interlocked.Read(ref _downloadedBytes) / _totalBytes * 100 : 0;
+        if (completed) pct = 100;
+        return new ModelDownloadStatus(completed, pct);
     }
 }

--- a/tests/DocflowAi.Net.Tests.Unit/LlmModelServiceTests.cs
+++ b/tests/DocflowAi.Net.Tests.Unit/LlmModelServiceTests.cs
@@ -10,14 +10,34 @@ namespace DocflowAi.Net.Tests.Unit;
 
 public class LlmModelServiceTests
 {
-    private static HttpClient CreateClient(HttpStatusCode status, byte[] content)
+    [Fact]
+    public async Task SwitchModelAsync_SwitchesImmediately_WhenFileExists()
     {
-        var handler = new MockHttpMessageHandler(status, content);
-        return new HttpClient(handler);
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+        Environment.SetEnvironmentVariable("MODELS_DIR", tempDir);
+        var dest = Path.Combine(tempDir, "file.bin");
+        await File.WriteAllBytesAsync(dest, new byte[] {1});
+
+        var opts = Options.Create(new LlmOptions { ModelPath = "default", ContextTokens = 1 });
+        var logger = LoggerFactory.Create(b => { }).CreateLogger<LlmModelService>();
+        var client = new HttpClient(new ThrowHandler());
+        var svc = new LlmModelService(client, opts, logger);
+
+        await svc.SwitchModelAsync("k", "repo", "file.bin", 5, CancellationToken.None);
+
+        opts.Value.ModelPath.Should().Be(dest);
+        opts.Value.ContextTokens.Should().Be(5);
+        var status = svc.GetStatus();
+        status.Completed.Should().BeTrue();
+        status.Percentage.Should().Be(100);
+
+        Environment.SetEnvironmentVariable("MODELS_DIR", null);
+        Directory.Delete(tempDir, true);
     }
 
     [Fact]
-    public async Task SwitchModelAsync_DownloadsAndUpdatesOptions()
+    public async Task SwitchModelAsync_ReportsProgressUntilCompleted()
     {
         var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
         Directory.CreateDirectory(tempDir);
@@ -25,18 +45,73 @@ public class LlmModelServiceTests
 
         var opts = Options.Create(new LlmOptions { ModelPath = "default", ContextTokens = 1 });
         var logger = LoggerFactory.Create(b => { }).CreateLogger<LlmModelService>();
-        var client = CreateClient(HttpStatusCode.OK, new byte[] {1,2,3});
+        var handler = new SlowHandler();
+        var client = new HttpClient(handler);
         var svc = new LlmModelService(client, opts, logger);
 
-        await svc.SwitchModelAsync("k", "repo", "file.bin", 2048, CancellationToken.None);
+        await svc.SwitchModelAsync("k", "repo", "file.bin", 11, CancellationToken.None);
+
+        var initial = svc.GetStatus();
+        initial.Completed.Should().BeFalse();
+        initial.Percentage.Should().Be(0);
+
+        handler.Complete(new byte[] {1,2,3,4});
+        await WaitForCompletionAsync(svc);
 
         var expectedPath = Path.Combine(tempDir, "file.bin");
         File.Exists(expectedPath).Should().BeTrue();
         opts.Value.ModelPath.Should().Be(expectedPath);
-        opts.Value.ContextTokens.Should().Be(2048);
+        opts.Value.ContextTokens.Should().Be(11);
+        var finalStatus = svc.GetStatus();
+        finalStatus.Completed.Should().BeTrue();
+        finalStatus.Percentage.Should().Be(100);
 
         Environment.SetEnvironmentVariable("MODELS_DIR", null);
         Directory.Delete(tempDir, true);
+    }
+
+    private static async Task WaitForCompletionAsync(LlmModelService svc)
+    {
+        for (var i = 0; i < 50; i++)
+        {
+            if (svc.GetStatus().Completed)
+                return;
+            await Task.Delay(100);
+        }
+        throw new TimeoutException();
+    }
+
+    private sealed class ThrowHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => throw new InvalidOperationException("No HTTP calls expected");
+    }
+
+    private sealed class SlowHandler : HttpMessageHandler
+    {
+        private readonly TaskCompletionSource<byte[]> _tcs = new();
+        public void Complete(byte[] content) => _tcs.SetResult(content);
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (request.Method == HttpMethod.Head)
+            {
+                var resp = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new ByteArrayContent(Array.Empty<byte>())
+                };
+                resp.Content.Headers.ContentLength = 4;
+                return Task.FromResult(resp);
+            }
+
+            return _tcs.Task.ContinueWith(t =>
+            {
+                var resp = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new ByteArrayContent(t.Result)
+                };
+                return resp;
+            }, cancellationToken);
+        }
     }
 
     [Fact]
@@ -48,7 +123,8 @@ public class LlmModelServiceTests
 
         var opts = Options.Create(new LlmOptions { ModelPath = "default", ContextTokens = 1 });
         var logger = LoggerFactory.Create(b => { }).CreateLogger<LlmModelService>();
-        var client = CreateClient(HttpStatusCode.NotFound, Array.Empty<byte>());
+        var handler = new NotFoundHandler();
+        var client = new HttpClient(handler);
         var svc = new LlmModelService(client, opts, logger);
 
         await Assert.ThrowsAsync<FileNotFoundException>(() => svc.SwitchModelAsync("k", "repo", "file.bin", 10, CancellationToken.None));
@@ -57,22 +133,9 @@ public class LlmModelServiceTests
         Directory.Delete(tempDir, true);
     }
 
-    private class MockHttpMessageHandler : HttpMessageHandler
+    private sealed class NotFoundHandler : HttpMessageHandler
     {
-        private readonly HttpStatusCode _status;
-        private readonly byte[] _content;
-        public MockHttpMessageHandler(HttpStatusCode status, byte[] content)
-        {
-            _status = status;
-            _content = content;
-        }
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            var response = new HttpResponseMessage(_status)
-            {
-                Content = new ByteArrayContent(_content)
-            };
-            return Task.FromResult(response);
-        }
+            => Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
     }
 }

--- a/tests/DocflowAi.Net.Tests.Unit/LlmModelServiceTests.cs
+++ b/tests/DocflowAi.Net.Tests.Unit/LlmModelServiceTests.cs
@@ -1,0 +1,78 @@
+using System.Net;
+using System.Net.Http;
+using DocflowAi.Net.Application.Configuration;
+using DocflowAi.Net.Infrastructure.Llm;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace DocflowAi.Net.Tests.Unit;
+
+public class LlmModelServiceTests
+{
+    private static HttpClient CreateClient(HttpStatusCode status, byte[] content)
+    {
+        var handler = new MockHttpMessageHandler(status, content);
+        return new HttpClient(handler);
+    }
+
+    [Fact]
+    public async Task SwitchModelAsync_DownloadsAndUpdatesOptions()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+        Environment.SetEnvironmentVariable("MODELS_DIR", tempDir);
+
+        var opts = Options.Create(new LlmOptions { ModelPath = "default", ContextTokens = 1 });
+        var logger = LoggerFactory.Create(b => { }).CreateLogger<LlmModelService>();
+        var client = CreateClient(HttpStatusCode.OK, new byte[] {1,2,3});
+        var svc = new LlmModelService(client, opts, logger);
+
+        await svc.SwitchModelAsync("k", "repo", "file.bin", 2048, CancellationToken.None);
+
+        var expectedPath = Path.Combine(tempDir, "file.bin");
+        File.Exists(expectedPath).Should().BeTrue();
+        opts.Value.ModelPath.Should().Be(expectedPath);
+        opts.Value.ContextTokens.Should().Be(2048);
+
+        Environment.SetEnvironmentVariable("MODELS_DIR", null);
+        Directory.Delete(tempDir, true);
+    }
+
+    [Fact]
+    public async Task SwitchModelAsync_Throws_WhenNotFound()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+        Environment.SetEnvironmentVariable("MODELS_DIR", tempDir);
+
+        var opts = Options.Create(new LlmOptions { ModelPath = "default", ContextTokens = 1 });
+        var logger = LoggerFactory.Create(b => { }).CreateLogger<LlmModelService>();
+        var client = CreateClient(HttpStatusCode.NotFound, Array.Empty<byte>());
+        var svc = new LlmModelService(client, opts, logger);
+
+        await Assert.ThrowsAsync<FileNotFoundException>(() => svc.SwitchModelAsync("k", "repo", "file.bin", 10, CancellationToken.None));
+
+        Environment.SetEnvironmentVariable("MODELS_DIR", null);
+        Directory.Delete(tempDir, true);
+    }
+
+    private class MockHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _status;
+        private readonly byte[] _content;
+        public MockHttpMessageHandler(HttpStatusCode status, byte[] content)
+        {
+            _status = status;
+            _content = content;
+        }
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = new HttpResponseMessage(_status)
+            {
+                Content = new ByteArrayContent(_content)
+            };
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/tests/DocflowAi.Net.Tests.Unit/ModelControllerTests.cs
+++ b/tests/DocflowAi.Net.Tests.Unit/ModelControllerTests.cs
@@ -21,4 +21,18 @@ public class ModelControllerTests
         svc.Verify(x => x.SwitchModelAsync("k", "r", "f", 10, It.IsAny<CancellationToken>()), Times.Once);
         res.Should().BeOfType<OkResult>();
     }
+
+    [Fact]
+    public void Status_ReturnsServiceResult()
+    {
+        var svc = new Mock<ILlmModelService>();
+        var status = new ModelDownloadStatus(true, 100);
+        svc.Setup(x => x.GetStatus()).Returns(status);
+        var controller = new ModelController(svc.Object);
+
+        var res = controller.Status();
+
+        res.Result.Should().BeOfType<OkObjectResult>();
+        ((OkObjectResult)res.Result).Value.Should().Be(status);
+    }
 }

--- a/tests/DocflowAi.Net.Tests.Unit/ModelControllerTests.cs
+++ b/tests/DocflowAi.Net.Tests.Unit/ModelControllerTests.cs
@@ -1,0 +1,24 @@
+using DocflowAi.Net.Api.Controllers;
+using DocflowAi.Net.Api.Models;
+using DocflowAi.Net.Application.Abstractions;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+
+namespace DocflowAi.Net.Tests.Unit;
+
+public class ModelControllerTests
+{
+    [Fact]
+    public async Task Switch_InvokesService_ReturnsOk()
+    {
+        var svc = new Mock<ILlmModelService>();
+        var controller = new ModelController(svc.Object);
+        var req = new SwitchModelRequest { HfKey = "k", ModelRepo = "r", ModelFile = "f", ContextSize = 10 };
+
+        var res = await controller.Switch(req, default);
+
+        svc.Verify(x => x.SwitchModelAsync("k", "r", "f", 10, It.IsAny<CancellationToken>()), Times.Once);
+        res.Should().BeOfType<OkResult>();
+    }
+}


### PR DESCRIPTION
## Summary
- allow switching LLM model with HuggingFace download
- expose protected /api/v1/model/switch endpoint
- cover service and controller with unit tests

## Testing
- `dotnet build -c Release`
- `dotnet test -c Release`


------
https://chatgpt.com/codex/tasks/task_e_689cb566fff0832581b07a780295781a