### PR TITLE
Handle duplicate keys in LLM output

### DIFF
--- a/src/DocflowAi.Net.Infrastructure/Internals.cs
+++ b/src/DocflowAi.Net.Infrastructure/Internals.cs
@@ -1,0 +1,2 @@
+using System.Runtime.CompilerServices;
+[assembly: InternalsVisibleTo("DocflowAi.Net.Tests.Unit")]

--- a/tests/DocflowAi.Net.Tests.Unit/LlamaExtractorParseTests.cs
+++ b/tests/DocflowAi.Net.Tests.Unit/LlamaExtractorParseTests.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using DocflowAi.Net.Application.Profiles;
+using DocflowAi.Net.Domain.Extraction;
+using DocflowAi.Net.Infrastructure.Llm;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace DocflowAi.Net.Tests.Unit;
+
+public class LlamaExtractorParseTests
+{
+    [Fact]
+    public void ParseResult_AllowsDuplicateKeys_LastWins()
+    {
+        var profile = new ExtractionProfile
+        {
+            Name = "tpl",
+            DocumentType = "invoice",
+            Language = "en",
+            Fields = new List<FieldSpec>()
+        };
+        var raw = "{\"document_type\":\"invoice\",\"document_type\":\"receipt\",\"language\":\"en\",\"fields\":[]}";
+        var logger = LoggerFactory.Create(b => { }).CreateLogger<LlamaExtractor>();
+
+        var result = LlamaExtractor.ParseResult(raw, profile, profile.DocumentType, logger);
+
+        Assert.Equal("receipt", result.DocumentType);
+    }
+}


### PR DESCRIPTION
## Summary
- parse LLM JSON using `JsonDocument` to tolerate duplicate keys
- expose `LlamaExtractor.ParseResult` and add unit test for duplicate `document_type`
- allow unit tests to access internals
- document why `JsonDocument` is used despite JSON grammar constraints

## Testing
- `rg -n -i 'pytest|:8000|sidecar|MarkitdownException|MARKITDOWN_URL|PY_MARKITDOWN_ENABLED' --glob '!AGENTS.md'`
- `dotnet build -c Release`
- `dotnet test -c Release`


------
https://chatgpt.com/codex/tasks/task_e_689cb5a500608325a34fcee3164091e2