### PR TITLE
Add real API test plan and update test report

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,4 +325,6 @@ Alcune dipendenze/asset possono avere licenze diverse (es. dataset XFUND, modell
 * **Config:** `appsettings.*.json` (sezione `Resolver`, `LLM`)
 * **Submodule MarkItDownNet:** documentazione in `src/MarkItDownNet/`
 
+* **Real API Test Plan:** [docs/real-api-test-plan.md](docs/real-api-test-plan.md)
+* **Test Report:** [docs/test-report.md](docs/test-report.md)
 — fine —

--- a/docs/real-api-test-plan.md
+++ b/docs/real-api-test-plan.md
@@ -1,0 +1,124 @@
+# PIANO DI TEST DI INTEGRAZIONE (REAL API) — BACKEND (C#)
+
+Obiettivo: eseguire **test end-to-end reali** contro le API esposte (nessun mock), usando file e servizi reali. I test **non** modificano il backend e verificano il comportamento osservabile via REST.
+Ambito endpoint:
+- POST /v1/jobs (queued | ?mode=immediate)
+- GET  /v1/jobs (lista paginata)
+- GET  /v1/jobs/{id}
+- DELETE /v1/jobs/{id}
+- GET  /health/live
+- GET  /health/ready
+- (Hangfire dashboard: solo verifica raggiungibilità via URL pubblico, non API)
+
+⚙️ **ESECUZIONE SU RICHIESTA**
+- Framework: **xUnit** (o NUnit), libreria HTTP: **HttpClient**. Niente stub/mocks.
+- Categoria dei test: `Trait("Category","RealE2E")` (filtrabile con `--filter`).
+- Abilitazione tramite env var (esempio): `DOCFLOW_API_BASE_URL=https://<host>` e (opzionale) `DOCFLOW_HANGFIRE_PATH=/hangfire`.
+- I test **saltano** automaticamente se la base URL non è impostata.
+
+📦 **DATI & PREREQUISITI**
+- File di prova (cartella `TestData/` nel progetto test):
+  1) `sample.pdf` ~100–200KB (PDF valido)
+  2) `sample-large.pdf` > limite `UploadLimits.MaxRequestBodyMB` (es. 20% oltre)
+  3) `image.png` ~100KB (MIME consentito)
+  4) `evil.exe` ~10KB (MIME/estensione non ammessi)
+- Payload di esempio:
+  - `prompt_text`: "Estrai intestatario, totale, iva."
+  - `prompt_json`: `{ "task": "extract", "entities": ["buyer","total","vat"] }`
+  - `fields_json`: `{ "entities": [{"name":"buyer","type":"string"},{"name":"total","type":"number"},{"name":"vat","type":"number"}] }`
+- Utilità test:
+  - Generatore `Idempotency-Key` (GUID e SHA-256 di file+prompt+fields).
+  - Lettura header `Retry-After` **e** body `retry_after_seconds`.
+
+🧪 **SUITE E CASI (Arrange → Act → Assert)**
+
+### A) SMOKE & HEALTH
+A1. **Live_OK** – GET /health/live → 200.
+
+A2. **Ready_OK_or_Reasons** – GET /health/ready → 200 **oppure** 503 con `reasons[]` tra: `litedb_unavailable`, `data_root_not_writable`, `backpressure`. Se 503: asserire che `reasons` sia non vuoto.
+
+A3. **Hangfire_Accessible** (facoltativo) – Se `DOCFLOW_HANGFIRE_PATH` definito: fare una **HEAD/GET** all’URL pubblico; aspettarsi 200/401/403/redirect (non deve essere 404/5xx persistente).
+
+### B) SUBMIT — QUEUED (202)
+B1. **Submit_Queued_202_Minimal** – POST /v1/jobs con `sample.pdf`, `prompt_text`, `fields_json` → 202 `{ job_id, status_url }`. Verifica che GET {id} ritorni status `Queued` o `Running`.
+
+B2. **Submit_Queued_202_IdempotencyKey** – Ripeti lo stesso POST con header `Idempotency-Key: <K>` → 202 **stesso** `job_id`.
+
+B3. **Submit_Queued_202_DedupeHash** – Due POST in sequenza **senza** Idempotency-Key con **stesso** file/prompt/fields → 202 **stesso** `job_id` (dedupe entro finestra).
+
+### C) SUBMIT — IMMEDIATE (200)
+C1. **Immediate_200_Success** – POST /v1/jobs?mode=immediate con `sample.pdf` + `prompt_text` + `fields_json` → 200 `{ job_id, status="Succeeded", duration_ms, result_path? }`. GET {id} → `Succeeded`. Se `result_path` pubblico: GET file → 200 (facoltativo).
+
+C2. **Immediate_200_Failed** (se riproducibile) – Usare un input che generi failure (es. payload volutamente inconsistente) → 200 `{ status="Failed", error }`. GET {id} → `Failed`.
+
+C3. **Immediate_429_Capacity** (se ambiente con capacità limitata) – Avvia una immediate che impegna il servizio (eseguire due POST concorrenti in Task.WhenAll). Il secondo POST → 429 con header/body `Retry-After`. Nessun job nuovo se non previsto da fallback. Se il backend ha `FallbackToQueue=true`: il secondo → 202 queued (asserire differenza).
+
+C4. **Immediate_200_Cancelled** (opzionale) – Avvia immediate e **annulla** la richiesta client (CancellationToken) durante l’elaborazione. GET {id} → `Cancelled` (se supportato dal backend).
+
+### D) LISTA PAGINATA — GET /v1/jobs
+D1. **List_Default_Paged_Desc** – GET /v1/jobs?page=1&pageSize=20 → 200 { page, pageSize, total, items }. Verifica `items` ordinati per `createdAt` DESC (confronto `createdAt` dei primi 3).
+
+D2. **List_Pagination_NextPage** – Se `total` > pageSize, GET page=2 → elementi diversi e coerenza col totale.
+
+D3. **List_Filters_ClientSide** (solo FE) – (Il BE non espone filtri dedicati) — validare localmente che il subset filtrato da FE corrisponda ai `status` attesi (non serve chiamata extra al BE).
+
+### E) DETTAGLIO — GET /v1/jobs/{id}
+E1. **Get_ById_Existing** – Dal job creato in B1: GET {id} → 200; assert: campi base (status, derivedStatus, progress, timestamps). Se paths presenti: **non** dedurre stato dai file, ma verificare solo la **presenza** dei path.
+
+E2. **Get_ById_NotFound** – GET guid random → 404 `{ error:"not_found" }`.
+
+### F) CANCEL — DELETE /v1/jobs/{id}
+F1. **Cancel_Queued_202** – Su un job in `Queued`: DELETE → 202, GET {id} → `Cancelled`.
+
+F2. **Cancel_Running_202** (se possibile) – Se un job è `Running`: DELETE → 202, GET {id} → `Cancelled` (o `Running` per breve, poi `Cancelled`).
+
+F3. **Cancel_Terminal_409** – Su job `Succeeded` o `Failed`: DELETE → 409 `{ error:"conflict" }`.
+
+### G) BACKPRESSURE & RATE LIMIT (429)
+G1. **QueueFull_429_SubmitQueued** – Precondizione: coda piena (eseguire N submit finché GET /health/ready riporta reason `backpressure` oppure fino a ottenere 429). Nuovo POST queued → 429 `{ error:"queue_full" }` + header/body `Retry-After`.
+
+G2. **ImmediateCapacity_429_SubmitImmediate** – (Come C3) Due immediate in parallelo → uno dei due 429 `{ error:"immediate_capacity" }` + `Retry-After` (se backend senza fallback).
+
+G3. **RateLimited_429** (se policy attiva) – Invia >N submit in finestra breve → 429 `{ error:"rate_limited" }` + `Retry-After`.
+
+### H) ERRORI PAYLOAD & VALIDAZIONE
+H1. **PayloadTooLarge_413** – POST queued con `sample-large.pdf` → 413 `{ error:"payload_too_large" }`.
+
+H2. **MimeNotAllowed_400** – POST con `evil.exe` (octet-stream) → 400 `{ error:"bad_request" }`.
+
+H3. **BadJson_400** – `fields` o `prompt` JSON **non valido** → 400.
+
+H4. **InsufficientStorage_507** (se riproducibile) – (Solo se ambiente predisposto) POST che attivi 507 → 507 `{ error:"insufficient_storage" }`.
+
+### I) CONSISTENZA, IDP & DEDUPE
+I1. **IdempotencyKey_Reused_AfterRestart** (se riavvio possibile) – Submit con stessa `Idempotency-Key` **prima e dopo** un riavvio del servizio → stesso `job_id`.
+
+I2. **HashDedupe_Window** – Due submit identici a distanza < TTL dedupe → stesso `job_id`; a distanza > TTL → job diverso.
+
+### L) ARTEFATTI (paths.*)
+L1. **OutputJson_Available_OnSuccess** (se esposto) – Per job `Succeeded`: prova HTTP GET al `paths.output` (se pubblico) → 200 e `application/json`.
+
+L2. **ErrorTxt_Available_OnFailure** (se esposto) – Per job `Failed`: HTTP GET `paths.error` → 200 e `text/plain`.
+
+🧼 **CLEAN-UP**
+- I job **terminali** restano in sistema (TTL cleanup notturno); non è previsto “delete hard” via API.
+- I test generano **prefissi** nei prompt (es. `"[ITEST-<RunId>] ..."`) per facilitarne il riconoscimento in manutenzione.
+- I job `Queued/Running` creati dai test vanno cancellati con DELETE (F1/F2).
+
+📊 **OUTPUT & LOGGING**
+- Ogni test logga: `RequestId` (se header), `JobId`, tempi, esito, eventuale `Retry-After`.
+- Al termine produrre un **report JUnit/TRX** e un CSV con: TestId, JobId, Stato finale, Durata, Error.
+
+▶️ **ESECUZIONE (esempio)**
+- Precondizioni: backend raggiungibile con servizi reali.
+- Comandi:
+  - `set DOCFLOW_API_BASE_URL=https://host:port` (o export su Linux/Mac)
+  - `dotnet test -c Release --filter Category=RealE2E`
+  - (facoltativo) `--logger "trx;LogFileName=real-e2e.trx"`
+
+✅ **CRITERI DI ACCETTAZIONE**
+- Tutti i casi A–H **passano**. I casi opzionali (C4, F2, G3, H4, I1) passano se l’ambiente li rende riproducibili.
+- Per i 429, è presente `Retry-After` **in header o body**.
+- Immediate vs queued: **200** (immediate) e **202** (queued) rispettati; GET {id} coerente con stato terminale.
+- Health: `/health/live` 200; `/health/ready` → 200 o 503 con reasons non vuote.
+- Nessuna dipendenza da file locali del server: i test accedono ai `paths.*` **solo** se esposti pubblicamente.

--- a/docs/test-report.md
+++ b/docs/test-report.md
@@ -1,0 +1,214 @@
+# Test Report
+
+Generated on Thu Aug 14 11:42:53 UTC 2025.
+
+## Key File Results
+- DatasetTests.DatasetFilesExist verifica la presenza di `sample_invoice.pdf` e `sample_invoice.png`.
+- DatasetMarkdownNetTests.SamplePdf_ConversionMatchesReference estrae "ACME" e 36 box dal PDF.
+- DatasetMarkdownNetTests.SamplePng_ContainsExpectedWords conferma che l'OCR del PNG contiene le parole attese.
+
+## Build
+```
+  Determining projects to restore...
+  Restored /workspace/docflow-ai-net/tests/DocflowAi.Net.BBoxResolver.Tests/DocflowAi.Net.BBoxResolver.Tests.csproj (in 3.85 sec).
+  Failed to download package 'Serilog.Sinks.File.7.0.0' from 'https://api.nuget.org/v3-flatcontainer/serilog.sinks.file/7.0.0/serilog.sinks.file.7.0.0.nupkg'.
+  Response status code does not indicate success: 503 (Service Unavailable).
+  Failed to download package 'Serilog.Extensions.Logging.9.0.2' from 'https://api.nuget.org/v3-flatcontainer/serilog.extensions.logging/9.0.2/serilog.extensions.logging.9.0.2.nupkg'.
+  Response status code does not indicate success: 503 (Service Unavailable).
+  Restored /workspace/docflow-ai-net/src/DocflowAi.Net.Infrastructure/DocflowAi.Net.Infrastructure.csproj (in 17.35 sec).
+  Restored /workspace/docflow-ai-net/src/DocflowAi.Net.Domain/DocflowAi.Net.Domain.csproj (in 12 ms).
+  Restored /workspace/docflow-ai-net/src/DocflowAi.Net.BBoxResolver/DocflowAi.Net.BBoxResolver.csproj (in 17 ms).
+/workspace/docflow-ai-net/tools/XFundEvalRunner/XFundEvalRunner.csproj : warning NU1903: Package 'System.Text.Json' 8.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-8g4q-xg66-9fp4 [/workspace/docflow-ai-net/docflow-ai-net.sln]
+/workspace/docflow-ai-net/tools/XFundEvalRunner/XFundEvalRunner.csproj : warning NU1903: Package 'System.Text.Json' 8.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-hh2w-p6rv-4g7w [/workspace/docflow-ai-net/docflow-ai-net.sln]
+  Restored /workspace/docflow-ai-net/tools/XFundEvalRunner/XFundEvalRunner.csproj (in 1.74 sec).
+  Restored /workspace/docflow-ai-net/tools/BBoxEvalRunner/BBoxEvalRunner.csproj (in 2 ms).
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Unit/DocflowAi.Net.Tests.Unit.csproj : warning NU1903: Package 'System.Net.Http' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-7jgj-8wvc-jh57 [/workspace/docflow-ai-net/docflow-ai-net.sln]
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Unit/DocflowAi.Net.Tests.Unit.csproj : warning NU1903: Package 'System.Text.RegularExpressions' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-cmhx-cq75-c4mj [/workspace/docflow-ai-net/docflow-ai-net.sln]
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Api.Tests/DocflowAi.Net.Api.Tests.csproj : warning NU1903: Package 'System.Net.Http' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-7jgj-8wvc-jh57 [/workspace/docflow-ai-net/docflow-ai-net.sln]
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Api.Tests/DocflowAi.Net.Api.Tests.csproj : warning NU1903: Package 'System.Text.RegularExpressions' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-cmhx-cq75-c4mj [/workspace/docflow-ai-net/docflow-ai-net.sln]
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/DocflowAi.Net.Tests.Integration.csproj : warning NU1603: DocflowAi.Net.Tests.Integration depends on Verify.Xunit (>= 24.7.2) but Verify.Xunit 24.7.2 was not found. Verify.Xunit 25.0.0 was resolved instead. [/workspace/docflow-ai-net/docflow-ai-net.sln]
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/DocflowAi.Net.Tests.Integration.csproj : warning NU1903: Package 'System.Net.Http' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-7jgj-8wvc-jh57 [/workspace/docflow-ai-net/docflow-ai-net.sln]
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/DocflowAi.Net.Tests.Integration.csproj : warning NU1903: Package 'System.Text.RegularExpressions' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-cmhx-cq75-c4mj [/workspace/docflow-ai-net/docflow-ai-net.sln]
+  Restored /workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Unit/DocflowAi.Net.Tests.Unit.csproj (in 23.42 sec).
+  Restored /workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/DocflowAi.Net.Tests.Integration.csproj (in 23.42 sec).
+  Restored /workspace/docflow-ai-net/src/DocflowAi.Net.Application/DocflowAi.Net.Application.csproj (in 3 ms).
+  Restored /workspace/docflow-ai-net/tests/DocflowAi.Net.Api.Tests/DocflowAi.Net.Api.Tests.csproj (in 23.42 sec).
+/workspace/docflow-ai-net/src/DocflowAi.Net.Api/DocflowAi.Net.Api.csproj : warning NU1903: Package 'Newtonsoft.Json' 11.0.1 has a known high severity vulnerability, https://github.com/advisories/GHSA-5crp-9r3c-p9vr [/workspace/docflow-ai-net/docflow-ai-net.sln]
+/workspace/docflow-ai-net/src/DocflowAi.Net.Api/DocflowAi.Net.Api.csproj : warning NU1903: Package 'System.Net.Http' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-7jgj-8wvc-jh57 [/workspace/docflow-ai-net/docflow-ai-net.sln]
+/workspace/docflow-ai-net/src/DocflowAi.Net.Api/DocflowAi.Net.Api.csproj : warning NU1903: Package 'System.Text.RegularExpressions' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-cmhx-cq75-c4mj [/workspace/docflow-ai-net/docflow-ai-net.sln]
+  Restored /workspace/docflow-ai-net/markitdownnet/src/MarkItDownNet/MarkItDownNet.csproj (in 8 ms).
+  Restored /workspace/docflow-ai-net/src/DocflowAi.Net.Api/DocflowAi.Net.Api.csproj (in 23 ms).
+/workspace/docflow-ai-net/tests/XFundEvalRunner.Tests/XFundEvalRunner.Tests.csproj : warning NU1903: Package 'System.Text.Json' 8.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-8g4q-xg66-9fp4 [/workspace/docflow-ai-net/docflow-ai-net.sln]
+/workspace/docflow-ai-net/tests/XFundEvalRunner.Tests/XFundEvalRunner.Tests.csproj : warning NU1903: Package 'System.Text.Json' 8.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-hh2w-p6rv-4g7w [/workspace/docflow-ai-net/docflow-ai-net.sln]
+  Restored /workspace/docflow-ai-net/tests/XFundEvalRunner.Tests/XFundEvalRunner.Tests.csproj (in 1.3 sec).
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Unit/DocflowAi.Net.Tests.Unit.csproj : warning NU1903: Package 'System.Net.Http' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-7jgj-8wvc-jh57
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Api.Tests/DocflowAi.Net.Api.Tests.csproj : warning NU1903: Package 'System.Net.Http' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-7jgj-8wvc-jh57
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Api.Tests/DocflowAi.Net.Api.Tests.csproj : warning NU1903: Package 'System.Text.RegularExpressions' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-cmhx-cq75-c4mj
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Unit/DocflowAi.Net.Tests.Unit.csproj : warning NU1903: Package 'System.Text.RegularExpressions' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-cmhx-cq75-c4mj
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/DocflowAi.Net.Tests.Integration.csproj : warning NU1603: DocflowAi.Net.Tests.Integration depends on Verify.Xunit (>= 24.7.2) but Verify.Xunit 24.7.2 was not found. Verify.Xunit 25.0.0 was resolved instead.
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/DocflowAi.Net.Tests.Integration.csproj : warning NU1903: Package 'System.Net.Http' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-7jgj-8wvc-jh57
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/DocflowAi.Net.Tests.Integration.csproj : warning NU1903: Package 'System.Text.RegularExpressions' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-cmhx-cq75-c4mj
+/workspace/docflow-ai-net/src/DocflowAi.Net.Api/DocflowAi.Net.Api.csproj : warning NU1903: Package 'Newtonsoft.Json' 11.0.1 has a known high severity vulnerability, https://github.com/advisories/GHSA-5crp-9r3c-p9vr
+/workspace/docflow-ai-net/src/DocflowAi.Net.Api/DocflowAi.Net.Api.csproj : warning NU1903: Package 'System.Net.Http' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-7jgj-8wvc-jh57
+/workspace/docflow-ai-net/src/DocflowAi.Net.Api/DocflowAi.Net.Api.csproj : warning NU1903: Package 'System.Text.RegularExpressions' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-cmhx-cq75-c4mj
+/workspace/docflow-ai-net/tests/XFundEvalRunner.Tests/XFundEvalRunner.Tests.csproj : warning NU1903: Package 'System.Text.Json' 8.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-8g4q-xg66-9fp4
+/workspace/docflow-ai-net/tests/XFundEvalRunner.Tests/XFundEvalRunner.Tests.csproj : warning NU1903: Package 'System.Text.Json' 8.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-hh2w-p6rv-4g7w
+/workspace/docflow-ai-net/tools/XFundEvalRunner/XFundEvalRunner.csproj : warning NU1903: Package 'System.Text.Json' 8.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-8g4q-xg66-9fp4
+/workspace/docflow-ai-net/tools/XFundEvalRunner/XFundEvalRunner.csproj : warning NU1903: Package 'System.Text.Json' 8.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-hh2w-p6rv-4g7w
+  DocflowAi.Net.BBoxResolver -> /workspace/docflow-ai-net/src/DocflowAi.Net.BBoxResolver/bin/Release/net9.0/DocflowAi.Net.BBoxResolver.dll
+  XFundEvalRunner -> /workspace/docflow-ai-net/tools/XFundEvalRunner/bin/Release/net9.0/XFundEvalRunner.dll
+/workspace/docflow-ai-net/markitdownnet/src/MarkItDownNet/MarkItDownConverter.cs(94,32): warning CA1416: This call site is reachable on all platforms. 'Conversion.ToImages(Stream, bool, string?, RenderOptions)' is only supported on: 'Android' 31.0 and later, 'iOS' 13.6 and later, 'Linux', 'maccatalyst' 13.5 and later, 'macOS/OSX', 'Windows'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416) [/workspace/docflow-ai-net/markitdownnet/src/MarkItDownNet/MarkItDownNet.csproj]
+  BBoxEvalRunner -> /workspace/docflow-ai-net/tools/BBoxEvalRunner/bin/Release/net9.0/BBoxEvalRunner.dll
+  MarkItDownNet -> /workspace/docflow-ai-net/markitdownnet/src/MarkItDownNet/bin/Release/net9.0/MarkItDownNet.dll
+  DocflowAi.Net.Domain -> /workspace/docflow-ai-net/src/DocflowAi.Net.Domain/bin/Release/net9.0/DocflowAi.Net.Domain.dll
+  DocflowAi.Net.Application -> /workspace/docflow-ai-net/src/DocflowAi.Net.Application/bin/Release/net9.0/DocflowAi.Net.Application.dll
+  DocflowAi.Net.BBoxResolver.Tests -> /workspace/docflow-ai-net/tests/DocflowAi.Net.BBoxResolver.Tests/bin/Release/net9.0/DocflowAi.Net.BBoxResolver.Tests.dll
+  XFundEvalRunner.Tests -> /workspace/docflow-ai-net/tests/XFundEvalRunner.Tests/bin/Release/net9.0/XFundEvalRunner.Tests.dll
+  DocflowAi.Net.Infrastructure -> /workspace/docflow-ai-net/src/DocflowAi.Net.Infrastructure/bin/Release/net9.0/DocflowAi.Net.Infrastructure.dll
+/workspace/docflow-ai-net/src/DocflowAi.Net.Api/Security/ApiKeyAuthenticationHandler.cs(5,137): warning CS0618: 'ISystemClock' is obsolete: 'Use TimeProvider instead.' [/workspace/docflow-ai-net/src/DocflowAi.Net.Api/DocflowAi.Net.Api.csproj]
+/workspace/docflow-ai-net/src/DocflowAi.Net.Api/Security/ApiKeyAuthenticationHandler.cs(5,190): warning CS0618: 'AuthenticationHandler<AuthenticationSchemeOptions>.AuthenticationHandler(IOptionsMonitor<AuthenticationSchemeOptions>, ILoggerFactory, UrlEncoder, ISystemClock)' is obsolete: 'ISystemClock is obsolete, use TimeProvider on AuthenticationSchemeOptions instead.' [/workspace/docflow-ai-net/src/DocflowAi.Net.Api/DocflowAi.Net.Api.csproj]
+/workspace/docflow-ai-net/src/DocflowAi.Net.Api/Program.cs(177,29): warning CS8604: Possible null reference argument for parameter 'value' in 'void IDiagnosticContext.Set(string propertyName, object value, bool destructureObjects = false)'. [/workspace/docflow-ai-net/src/DocflowAi.Net.Api/DocflowAi.Net.Api.csproj]
+  DocflowAi.Net.Api -> /workspace/docflow-ai-net/src/DocflowAi.Net.Api/bin/Release/net9.0/DocflowAi.Net.Api.dll
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Api.Tests/Fakes/FakeProcessService.cs(39,53): warning CS8625: Cannot convert null literal to non-nullable reference type. [/workspace/docflow-ai-net/tests/DocflowAi.Net.Api.Tests/DocflowAi.Net.Api.Tests.csproj]
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/MarkdownNetConverterTests.cs(211,65): warning CS0618: 'SKPaint.TextSize' is obsolete: 'Use SKFont.Size instead.' [/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/DocflowAi.Net.Tests.Integration.csproj]
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/MarkdownNetConverterTests.cs(212,9): warning CS0618: 'SKCanvas.DrawText(string, float, float, SKPaint)' is obsolete: 'Use DrawText(string text, float x, float y, SKTextAlign textAlign, SKFont font, SKPaint paint) instead.' [/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/DocflowAi.Net.Tests.Integration.csproj]
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/MarkdownNetConverterTests.cs(223,65): warning CS0618: 'SKPaint.TextSize' is obsolete: 'Use SKFont.Size instead.' [/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/DocflowAi.Net.Tests.Integration.csproj]
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/MarkdownNetConverterTests.cs(224,9): warning CS0618: 'SKCanvas.DrawText(string, float, float, SKPaint)' is obsolete: 'Use DrawText(string text, float x, float y, SKTextAlign textAlign, SKFont font, SKPaint paint) instead.' [/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/DocflowAi.Net.Tests.Integration.csproj]
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/MarkdownNetConverterTests.cs(236,69): warning CS0618: 'SKPaint.TextSize' is obsolete: 'Use SKFont.Size instead.' [/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/DocflowAi.Net.Tests.Integration.csproj]
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/MarkdownNetConverterTests.cs(237,13): warning CS0618: 'SKCanvas.DrawText(string, float, float, SKPaint)' is obsolete: 'Use DrawText(string text, float x, float y, SKTextAlign textAlign, SKFont font, SKPaint paint) instead.' [/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/DocflowAi.Net.Tests.Integration.csproj]
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/MarkdownNetConverterTests.cs(260,65): warning CS0618: 'SKPaint.TextSize' is obsolete: 'Use SKFont.Size instead.' [/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/DocflowAi.Net.Tests.Integration.csproj]
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/MarkdownNetConverterTests.cs(261,9): warning CS0618: 'SKCanvas.DrawText(string, float, float, SKPaint)' is obsolete: 'Use DrawText(string text, float x, float y, SKTextAlign textAlign, SKFont font, SKPaint paint) instead.' [/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/DocflowAi.Net.Tests.Integration.csproj]
+  DocflowAi.Net.Api.Tests -> /workspace/docflow-ai-net/tests/DocflowAi.Net.Api.Tests/bin/Release/net9.0/DocflowAi.Net.Api.Tests.dll
+  DocflowAi.Net.Tests.Integration -> /workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/bin/Release/net9.0/DocflowAi.Net.Tests.Integration.dll
+  DocflowAi.Net.Tests.Unit -> /workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Unit/bin/Release/net9.0/DocflowAi.Net.Tests.Unit.dll
+
+Build succeeded.
+
+/workspace/docflow-ai-net/tools/XFundEvalRunner/XFundEvalRunner.csproj : warning NU1903: Package 'System.Text.Json' 8.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-8g4q-xg66-9fp4 [/workspace/docflow-ai-net/docflow-ai-net.sln]
+/workspace/docflow-ai-net/tools/XFundEvalRunner/XFundEvalRunner.csproj : warning NU1903: Package 'System.Text.Json' 8.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-hh2w-p6rv-4g7w [/workspace/docflow-ai-net/docflow-ai-net.sln]
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Unit/DocflowAi.Net.Tests.Unit.csproj : warning NU1903: Package 'System.Net.Http' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-7jgj-8wvc-jh57 [/workspace/docflow-ai-net/docflow-ai-net.sln]
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Unit/DocflowAi.Net.Tests.Unit.csproj : warning NU1903: Package 'System.Text.RegularExpressions' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-cmhx-cq75-c4mj [/workspace/docflow-ai-net/docflow-ai-net.sln]
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Api.Tests/DocflowAi.Net.Api.Tests.csproj : warning NU1903: Package 'System.Net.Http' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-7jgj-8wvc-jh57 [/workspace/docflow-ai-net/docflow-ai-net.sln]
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Api.Tests/DocflowAi.Net.Api.Tests.csproj : warning NU1903: Package 'System.Text.RegularExpressions' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-cmhx-cq75-c4mj [/workspace/docflow-ai-net/docflow-ai-net.sln]
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/DocflowAi.Net.Tests.Integration.csproj : warning NU1603: DocflowAi.Net.Tests.Integration depends on Verify.Xunit (>= 24.7.2) but Verify.Xunit 24.7.2 was not found. Verify.Xunit 25.0.0 was resolved instead. [/workspace/docflow-ai-net/docflow-ai-net.sln]
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/DocflowAi.Net.Tests.Integration.csproj : warning NU1903: Package 'System.Net.Http' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-7jgj-8wvc-jh57 [/workspace/docflow-ai-net/docflow-ai-net.sln]
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/DocflowAi.Net.Tests.Integration.csproj : warning NU1903: Package 'System.Text.RegularExpressions' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-cmhx-cq75-c4mj [/workspace/docflow-ai-net/docflow-ai-net.sln]
+/workspace/docflow-ai-net/src/DocflowAi.Net.Api/DocflowAi.Net.Api.csproj : warning NU1903: Package 'Newtonsoft.Json' 11.0.1 has a known high severity vulnerability, https://github.com/advisories/GHSA-5crp-9r3c-p9vr [/workspace/docflow-ai-net/docflow-ai-net.sln]
+/workspace/docflow-ai-net/src/DocflowAi.Net.Api/DocflowAi.Net.Api.csproj : warning NU1903: Package 'System.Net.Http' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-7jgj-8wvc-jh57 [/workspace/docflow-ai-net/docflow-ai-net.sln]
+/workspace/docflow-ai-net/src/DocflowAi.Net.Api/DocflowAi.Net.Api.csproj : warning NU1903: Package 'System.Text.RegularExpressions' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-cmhx-cq75-c4mj [/workspace/docflow-ai-net/docflow-ai-net.sln]
+/workspace/docflow-ai-net/tests/XFundEvalRunner.Tests/XFundEvalRunner.Tests.csproj : warning NU1903: Package 'System.Text.Json' 8.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-8g4q-xg66-9fp4 [/workspace/docflow-ai-net/docflow-ai-net.sln]
+/workspace/docflow-ai-net/tests/XFundEvalRunner.Tests/XFundEvalRunner.Tests.csproj : warning NU1903: Package 'System.Text.Json' 8.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-hh2w-p6rv-4g7w [/workspace/docflow-ai-net/docflow-ai-net.sln]
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Unit/DocflowAi.Net.Tests.Unit.csproj : warning NU1903: Package 'System.Net.Http' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-7jgj-8wvc-jh57
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Api.Tests/DocflowAi.Net.Api.Tests.csproj : warning NU1903: Package 'System.Net.Http' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-7jgj-8wvc-jh57
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Api.Tests/DocflowAi.Net.Api.Tests.csproj : warning NU1903: Package 'System.Text.RegularExpressions' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-cmhx-cq75-c4mj
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Unit/DocflowAi.Net.Tests.Unit.csproj : warning NU1903: Package 'System.Text.RegularExpressions' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-cmhx-cq75-c4mj
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/DocflowAi.Net.Tests.Integration.csproj : warning NU1603: DocflowAi.Net.Tests.Integration depends on Verify.Xunit (>= 24.7.2) but Verify.Xunit 24.7.2 was not found. Verify.Xunit 25.0.0 was resolved instead.
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/DocflowAi.Net.Tests.Integration.csproj : warning NU1903: Package 'System.Net.Http' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-7jgj-8wvc-jh57
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/DocflowAi.Net.Tests.Integration.csproj : warning NU1903: Package 'System.Text.RegularExpressions' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-cmhx-cq75-c4mj
+/workspace/docflow-ai-net/src/DocflowAi.Net.Api/DocflowAi.Net.Api.csproj : warning NU1903: Package 'Newtonsoft.Json' 11.0.1 has a known high severity vulnerability, https://github.com/advisories/GHSA-5crp-9r3c-p9vr
+/workspace/docflow-ai-net/src/DocflowAi.Net.Api/DocflowAi.Net.Api.csproj : warning NU1903: Package 'System.Net.Http' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-7jgj-8wvc-jh57
+/workspace/docflow-ai-net/src/DocflowAi.Net.Api/DocflowAi.Net.Api.csproj : warning NU1903: Package 'System.Text.RegularExpressions' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-cmhx-cq75-c4mj
+/workspace/docflow-ai-net/tests/XFundEvalRunner.Tests/XFundEvalRunner.Tests.csproj : warning NU1903: Package 'System.Text.Json' 8.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-8g4q-xg66-9fp4
+/workspace/docflow-ai-net/tests/XFundEvalRunner.Tests/XFundEvalRunner.Tests.csproj : warning NU1903: Package 'System.Text.Json' 8.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-hh2w-p6rv-4g7w
+/workspace/docflow-ai-net/tools/XFundEvalRunner/XFundEvalRunner.csproj : warning NU1903: Package 'System.Text.Json' 8.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-8g4q-xg66-9fp4
+/workspace/docflow-ai-net/tools/XFundEvalRunner/XFundEvalRunner.csproj : warning NU1903: Package 'System.Text.Json' 8.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-hh2w-p6rv-4g7w
+/workspace/docflow-ai-net/markitdownnet/src/MarkItDownNet/MarkItDownConverter.cs(94,32): warning CA1416: This call site is reachable on all platforms. 'Conversion.ToImages(Stream, bool, string?, RenderOptions)' is only supported on: 'Android' 31.0 and later, 'iOS' 13.6 and later, 'Linux', 'maccatalyst' 13.5 and later, 'macOS/OSX', 'Windows'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416) [/workspace/docflow-ai-net/markitdownnet/src/MarkItDownNet/MarkItDownNet.csproj]
+/workspace/docflow-ai-net/src/DocflowAi.Net.Api/Security/ApiKeyAuthenticationHandler.cs(5,137): warning CS0618: 'ISystemClock' is obsolete: 'Use TimeProvider instead.' [/workspace/docflow-ai-net/src/DocflowAi.Net.Api/DocflowAi.Net.Api.csproj]
+/workspace/docflow-ai-net/src/DocflowAi.Net.Api/Security/ApiKeyAuthenticationHandler.cs(5,190): warning CS0618: 'AuthenticationHandler<AuthenticationSchemeOptions>.AuthenticationHandler(IOptionsMonitor<AuthenticationSchemeOptions>, ILoggerFactory, UrlEncoder, ISystemClock)' is obsolete: 'ISystemClock is obsolete, use TimeProvider on AuthenticationSchemeOptions instead.' [/workspace/docflow-ai-net/src/DocflowAi.Net.Api/DocflowAi.Net.Api.csproj]
+/workspace/docflow-ai-net/src/DocflowAi.Net.Api/Program.cs(177,29): warning CS8604: Possible null reference argument for parameter 'value' in 'void IDiagnosticContext.Set(string propertyName, object value, bool destructureObjects = false)'. [/workspace/docflow-ai-net/src/DocflowAi.Net.Api/DocflowAi.Net.Api.csproj]
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Api.Tests/Fakes/FakeProcessService.cs(39,53): warning CS8625: Cannot convert null literal to non-nullable reference type. [/workspace/docflow-ai-net/tests/DocflowAi.Net.Api.Tests/DocflowAi.Net.Api.Tests.csproj]
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/MarkdownNetConverterTests.cs(211,65): warning CS0618: 'SKPaint.TextSize' is obsolete: 'Use SKFont.Size instead.' [/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/DocflowAi.Net.Tests.Integration.csproj]
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/MarkdownNetConverterTests.cs(212,9): warning CS0618: 'SKCanvas.DrawText(string, float, float, SKPaint)' is obsolete: 'Use DrawText(string text, float x, float y, SKTextAlign textAlign, SKFont font, SKPaint paint) instead.' [/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/DocflowAi.Net.Tests.Integration.csproj]
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/MarkdownNetConverterTests.cs(223,65): warning CS0618: 'SKPaint.TextSize' is obsolete: 'Use SKFont.Size instead.' [/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/DocflowAi.Net.Tests.Integration.csproj]
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/MarkdownNetConverterTests.cs(224,9): warning CS0618: 'SKCanvas.DrawText(string, float, float, SKPaint)' is obsolete: 'Use DrawText(string text, float x, float y, SKTextAlign textAlign, SKFont font, SKPaint paint) instead.' [/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/DocflowAi.Net.Tests.Integration.csproj]
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/MarkdownNetConverterTests.cs(236,69): warning CS0618: 'SKPaint.TextSize' is obsolete: 'Use SKFont.Size instead.' [/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/DocflowAi.Net.Tests.Integration.csproj]
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/MarkdownNetConverterTests.cs(237,13): warning CS0618: 'SKCanvas.DrawText(string, float, float, SKPaint)' is obsolete: 'Use DrawText(string text, float x, float y, SKTextAlign textAlign, SKFont font, SKPaint paint) instead.' [/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/DocflowAi.Net.Tests.Integration.csproj]
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/MarkdownNetConverterTests.cs(260,65): warning CS0618: 'SKPaint.TextSize' is obsolete: 'Use SKFont.Size instead.' [/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/DocflowAi.Net.Tests.Integration.csproj]
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/MarkdownNetConverterTests.cs(261,9): warning CS0618: 'SKCanvas.DrawText(string, float, float, SKPaint)' is obsolete: 'Use DrawText(string text, float x, float y, SKTextAlign textAlign, SKFont font, SKPaint paint) instead.' [/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/DocflowAi.Net.Tests.Integration.csproj]
+    41 Warning(s)
+    0 Error(s)
+
+Time Elapsed 00:00:54.85
+```
+
+## Test
+```
+  Determining projects to restore...
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Unit/DocflowAi.Net.Tests.Unit.csproj : warning NU1903: Package 'System.Net.Http' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-7jgj-8wvc-jh57 [/workspace/docflow-ai-net/docflow-ai-net.sln]
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Unit/DocflowAi.Net.Tests.Unit.csproj : warning NU1903: Package 'System.Text.RegularExpressions' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-cmhx-cq75-c4mj [/workspace/docflow-ai-net/docflow-ai-net.sln]
+/workspace/docflow-ai-net/tools/XFundEvalRunner/XFundEvalRunner.csproj : warning NU1903: Package 'System.Text.Json' 8.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-8g4q-xg66-9fp4 [/workspace/docflow-ai-net/docflow-ai-net.sln]
+/workspace/docflow-ai-net/tools/XFundEvalRunner/XFundEvalRunner.csproj : warning NU1903: Package 'System.Text.Json' 8.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-hh2w-p6rv-4g7w [/workspace/docflow-ai-net/docflow-ai-net.sln]
+/workspace/docflow-ai-net/tests/XFundEvalRunner.Tests/XFundEvalRunner.Tests.csproj : warning NU1903: Package 'System.Text.Json' 8.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-8g4q-xg66-9fp4 [/workspace/docflow-ai-net/docflow-ai-net.sln]
+/workspace/docflow-ai-net/tests/XFundEvalRunner.Tests/XFundEvalRunner.Tests.csproj : warning NU1903: Package 'System.Text.Json' 8.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-hh2w-p6rv-4g7w [/workspace/docflow-ai-net/docflow-ai-net.sln]
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/DocflowAi.Net.Tests.Integration.csproj : warning NU1603: DocflowAi.Net.Tests.Integration depends on Verify.Xunit (>= 24.7.2) but Verify.Xunit 24.7.2 was not found. Verify.Xunit 25.0.0 was resolved instead. [/workspace/docflow-ai-net/docflow-ai-net.sln]
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/DocflowAi.Net.Tests.Integration.csproj : warning NU1903: Package 'System.Net.Http' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-7jgj-8wvc-jh57 [/workspace/docflow-ai-net/docflow-ai-net.sln]
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/DocflowAi.Net.Tests.Integration.csproj : warning NU1903: Package 'System.Text.RegularExpressions' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-cmhx-cq75-c4mj [/workspace/docflow-ai-net/docflow-ai-net.sln]
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Api.Tests/DocflowAi.Net.Api.Tests.csproj : warning NU1903: Package 'System.Net.Http' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-7jgj-8wvc-jh57 [/workspace/docflow-ai-net/docflow-ai-net.sln]
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Api.Tests/DocflowAi.Net.Api.Tests.csproj : warning NU1903: Package 'System.Text.RegularExpressions' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-cmhx-cq75-c4mj [/workspace/docflow-ai-net/docflow-ai-net.sln]
+/workspace/docflow-ai-net/src/DocflowAi.Net.Api/DocflowAi.Net.Api.csproj : warning NU1903: Package 'Newtonsoft.Json' 11.0.1 has a known high severity vulnerability, https://github.com/advisories/GHSA-5crp-9r3c-p9vr [/workspace/docflow-ai-net/docflow-ai-net.sln]
+/workspace/docflow-ai-net/src/DocflowAi.Net.Api/DocflowAi.Net.Api.csproj : warning NU1903: Package 'System.Net.Http' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-7jgj-8wvc-jh57 [/workspace/docflow-ai-net/docflow-ai-net.sln]
+/workspace/docflow-ai-net/src/DocflowAi.Net.Api/DocflowAi.Net.Api.csproj : warning NU1903: Package 'System.Text.RegularExpressions' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-cmhx-cq75-c4mj [/workspace/docflow-ai-net/docflow-ai-net.sln]
+  All projects are up-to-date for restore.
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/DocflowAi.Net.Tests.Integration.csproj : warning NU1603: DocflowAi.Net.Tests.Integration depends on Verify.Xunit (>= 24.7.2) but Verify.Xunit 24.7.2 was not found. Verify.Xunit 25.0.0 was resolved instead.
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/DocflowAi.Net.Tests.Integration.csproj : warning NU1903: Package 'System.Net.Http' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-7jgj-8wvc-jh57
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/DocflowAi.Net.Tests.Integration.csproj : warning NU1903: Package 'System.Text.RegularExpressions' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-cmhx-cq75-c4mj
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Api.Tests/DocflowAi.Net.Api.Tests.csproj : warning NU1903: Package 'System.Net.Http' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-7jgj-8wvc-jh57
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Api.Tests/DocflowAi.Net.Api.Tests.csproj : warning NU1903: Package 'System.Text.RegularExpressions' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-cmhx-cq75-c4mj
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Unit/DocflowAi.Net.Tests.Unit.csproj : warning NU1903: Package 'System.Net.Http' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-7jgj-8wvc-jh57
+/workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Unit/DocflowAi.Net.Tests.Unit.csproj : warning NU1903: Package 'System.Text.RegularExpressions' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-cmhx-cq75-c4mj
+/workspace/docflow-ai-net/tests/XFundEvalRunner.Tests/XFundEvalRunner.Tests.csproj : warning NU1903: Package 'System.Text.Json' 8.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-8g4q-xg66-9fp4
+/workspace/docflow-ai-net/tests/XFundEvalRunner.Tests/XFundEvalRunner.Tests.csproj : warning NU1903: Package 'System.Text.Json' 8.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-hh2w-p6rv-4g7w
+/workspace/docflow-ai-net/tools/XFundEvalRunner/XFundEvalRunner.csproj : warning NU1903: Package 'System.Text.Json' 8.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-8g4q-xg66-9fp4
+/workspace/docflow-ai-net/tools/XFundEvalRunner/XFundEvalRunner.csproj : warning NU1903: Package 'System.Text.Json' 8.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-hh2w-p6rv-4g7w
+/workspace/docflow-ai-net/src/DocflowAi.Net.Api/DocflowAi.Net.Api.csproj : warning NU1903: Package 'Newtonsoft.Json' 11.0.1 has a known high severity vulnerability, https://github.com/advisories/GHSA-5crp-9r3c-p9vr
+/workspace/docflow-ai-net/src/DocflowAi.Net.Api/DocflowAi.Net.Api.csproj : warning NU1903: Package 'System.Net.Http' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-7jgj-8wvc-jh57
+/workspace/docflow-ai-net/src/DocflowAi.Net.Api/DocflowAi.Net.Api.csproj : warning NU1903: Package 'System.Text.RegularExpressions' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-cmhx-cq75-c4mj
+  MarkItDownNet -> /workspace/docflow-ai-net/markitdownnet/src/MarkItDownNet/bin/Release/net9.0/MarkItDownNet.dll
+  DocflowAi.Net.BBoxResolver -> /workspace/docflow-ai-net/src/DocflowAi.Net.BBoxResolver/bin/Release/net9.0/DocflowAi.Net.BBoxResolver.dll
+  XFundEvalRunner -> /workspace/docflow-ai-net/tools/XFundEvalRunner/bin/Release/net9.0/XFundEvalRunner.dll
+  XFundEvalRunner.Tests -> /workspace/docflow-ai-net/tests/XFundEvalRunner.Tests/bin/Release/net9.0/XFundEvalRunner.Tests.dll
+Test run for /workspace/docflow-ai-net/tests/XFundEvalRunner.Tests/bin/Release/net9.0/XFundEvalRunner.Tests.dll (.NETCoreApp,Version=v9.0)
+VSTest version 17.12.0 (x64)
+
+Starting test execution, please wait...
+A total of 1 test files matched the specified pattern.
+
+Passed!  - Failed:     0, Passed:     6, Skipped:     0, Total:     6, Duration: 126 ms - XFundEvalRunner.Tests.dll (net9.0)
+  DocflowAi.Net.Domain -> /workspace/docflow-ai-net/src/DocflowAi.Net.Domain/bin/Release/net9.0/DocflowAi.Net.Domain.dll
+  BBoxEvalRunner -> /workspace/docflow-ai-net/tools/BBoxEvalRunner/bin/Release/net9.0/BBoxEvalRunner.dll
+  DocflowAi.Net.Application -> /workspace/docflow-ai-net/src/DocflowAi.Net.Application/bin/Release/net9.0/DocflowAi.Net.Application.dll
+  DocflowAi.Net.Infrastructure -> /workspace/docflow-ai-net/src/DocflowAi.Net.Infrastructure/bin/Release/net9.0/DocflowAi.Net.Infrastructure.dll
+  DocflowAi.Net.BBoxResolver.Tests -> /workspace/docflow-ai-net/tests/DocflowAi.Net.BBoxResolver.Tests/bin/Release/net9.0/DocflowAi.Net.BBoxResolver.Tests.dll
+Test run for /workspace/docflow-ai-net/tests/DocflowAi.Net.BBoxResolver.Tests/bin/Release/net9.0/DocflowAi.Net.BBoxResolver.Tests.dll (.NETCoreApp,Version=v9.0)
+VSTest version 17.12.0 (x64)
+
+Starting test execution, please wait...
+A total of 1 test files matched the specified pattern.
+
+Passed!  - Failed:     0, Passed:    19, Skipped:     0, Total:    19, Duration: 726 ms - DocflowAi.Net.BBoxResolver.Tests.dll (net9.0)
+  DocflowAi.Net.Api -> /workspace/docflow-ai-net/src/DocflowAi.Net.Api/bin/Release/net9.0/DocflowAi.Net.Api.dll
+  DocflowAi.Net.Tests.Integration -> /workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/bin/Release/net9.0/DocflowAi.Net.Tests.Integration.dll
+  DocflowAi.Net.Tests.Unit -> /workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Unit/bin/Release/net9.0/DocflowAi.Net.Tests.Unit.dll
+Test run for /workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Unit/bin/Release/net9.0/DocflowAi.Net.Tests.Unit.dll (.NETCoreApp,Version=v9.0)
+Test run for /workspace/docflow-ai-net/tests/DocflowAi.Net.Tests.Integration/bin/Release/net9.0/DocflowAi.Net.Tests.Integration.dll (.NETCoreApp,Version=v9.0)
+  DocflowAi.Net.Api.Tests -> /workspace/docflow-ai-net/tests/DocflowAi.Net.Api.Tests/bin/Release/net9.0/DocflowAi.Net.Api.Tests.dll
+VSTest version 17.12.0 (x64)
+Test run for /workspace/docflow-ai-net/tests/DocflowAi.Net.Api.Tests/bin/Release/net9.0/DocflowAi.Net.Api.Tests.dll (.NETCoreApp,Version=v9.0)
+
+VSTest version 17.12.0 (x64)
+
+VSTest version 17.12.0 (x64)
+
+Starting test execution, please wait...
+Starting test execution, please wait...
+A total of 1 test files matched the specified pattern.
+Starting test execution, please wait...
+A total of 1 test files matched the specified pattern.
+A total of 1 test files matched the specified pattern.
+
+Passed!  - Failed:     0, Passed:    10, Skipped:     0, Total:    10, Duration: 729 ms - DocflowAi.Net.Tests.Unit.dll (net9.0)
+
+Passed!  - Failed:     0, Passed:    17, Skipped:     0, Total:    17, Duration: 2 s - DocflowAi.Net.Tests.Integration.dll (net9.0)
+
+Passed!  - Failed:     0, Passed:    48, Skipped:     0, Total:    48, Duration: 21 s - DocflowAi.Net.Api.Tests.dll (net9.0)
+```


### PR DESCRIPTION
## Summary
- document integration test plan for real API
- link real API test plan and test report from README quick references
- refresh test report with PDF/PNG highlights and latest build/test output

## Testing
- `rg -n -i 'pytest|:8000|sidecar|MarkitdownException|MARKITDOWN_URL|PY_MARKITDOWN_ENABLED'`
- `dotnet build -c Release`
- `dotnet test -c Release`


------
https://chatgpt.com/codex/tasks/task_e_689dc268a5dc8325980916ba227aaed2