### PR TITLE
Switch to hash-based routing

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,7 +4,7 @@ import { ConfigProvider, theme } from 'antd';
 import 'antd/dist/reset.css';
 import './index.css';
 import App from './App';
-import { BrowserRouter } from 'react-router-dom';
+import { HashRouter } from 'react-router-dom';
 import { OpenAPI } from './generated';
 
 OpenAPI.BASE = import.meta.env.VITE_API_BASE_URL;
@@ -12,9 +12,9 @@ OpenAPI.BASE = import.meta.env.VITE_API_BASE_URL;
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <ConfigProvider theme={{ algorithm: theme.defaultAlgorithm }}>
-      <BrowserRouter>
+      <HashRouter>
         <App />
-      </BrowserRouter>
+      </HashRouter>
     </ConfigProvider>
   </StrictMode>,
 );


### PR DESCRIPTION
## Summary
- use hash-based routing to avoid join errors after login

## Testing
- `npm test -- --run`
- `npm run build`
- `npm run e2e` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/...; requires `npx playwright install`)*
- `dotnet build -c Release`
- `dotnet test -c Release`


------
https://chatgpt.com/codex/tasks/task_e_689dd6a12ab8832591420ce436fb879a