### PR TITLE
fix: include model endpoints in swagger

### DIFF
--- a/frontend/src/pages/ModelManagerPage.tsx
+++ b/frontend/src/pages/ModelManagerPage.tsx
@@ -10,12 +10,10 @@ import dayjs from 'dayjs';
 
 export default function ModelManagerPage() {
   const [info, setInfo] = useState<ModelInfo | null>(null);
-  const [loadingInfo, setLoadingInfo] = useState(false);
   const [polling, setPolling] = useState(false);
   const [retryAfter, setRetryAfter] = useState<number | null>(null);
 
   const loadInfo = async () => {
-    setLoadingInfo(true);
     try {
       const data = await DefaultService.getModelInfo();
       setInfo(data);
@@ -24,7 +22,6 @@ export default function ModelManagerPage() {
         setRetryAfter(e.retryAfter ?? 0);
       }
     } finally {
-      setLoadingInfo(false);
     }
   };
 

--- a/frontend/swagger/v1/swagger.json
+++ b/frontend/swagger/v1/swagger.json
@@ -109,6 +109,52 @@
         }
       }
     }
+    ,"/model/switch": {
+      "post": {
+        "operationId": "switchModel",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": { "schema": { "$ref": "#/components/schemas/ModelSwitchRequest" } }
+          }
+        },
+        "responses": {
+          "202": { "description": "Accepted" }
+        }
+      },
+      "delete": {
+        "operationId": "cancelModelSwitch",
+        "responses": {
+          "202": { "description": "Accepted" }
+        }
+      }
+    },
+    "/model/status": {
+      "get": {
+        "operationId": "getModelStatus",
+        "responses": {
+          "200": {
+            "description": "Status",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/ModelStatus" } }
+            }
+          }
+        }
+      }
+    },
+    "/model/info": {
+      "get": {
+        "operationId": "getModelInfo",
+        "responses": {
+          "200": {
+            "description": "Model info",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/ModelInfo" } }
+            }
+          }
+        }
+      }
+    }
   },
   "components": {
     "schemas": {
@@ -163,6 +209,36 @@
           "reasons": { "type": "array", "items": { "type": "string" } }
         },
         "required": ["status", "reasons"]
+      },
+      "ModelSwitchRequest": {
+        "type": "object",
+        "properties": {
+          "token": { "type": "string" },
+          "repo": { "type": "string" },
+          "file": { "type": "string" },
+          "contextSize": { "type": "integer" },
+          "note": { "type": "string", "nullable": true }
+        },
+        "required": ["token", "repo", "file", "contextSize"]
+      },
+      "ModelStatus": {
+        "type": "object",
+        "properties": {
+          "completed": { "type": "boolean" },
+          "percentage": { "type": "number" },
+          "message": { "type": "string", "nullable": true }
+        },
+        "required": ["completed", "percentage"]
+      },
+      "ModelInfo": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string", "nullable": true },
+          "repo": { "type": "string", "nullable": true },
+          "file": { "type": "string", "nullable": true },
+          "contextSize": { "type": "integer", "nullable": true },
+          "loadedAt": { "type": "string", "format": "date-time", "nullable": true }
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- include model management endpoints in bundled swagger so API types are generated
- remove unused loading state from ModelManagerPage

## Testing
- `npm run build`
- `dotnet build -c Release`
- `dotnet test -c Release`


------
https://chatgpt.com/codex/tasks/task_e_689de1e8600883258ded11e50310e43c