### PR TITLE
fix: default API base URL

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -7,7 +7,8 @@ import App from './App';
 import { HashRouter } from 'react-router-dom';
 import { OpenAPI } from './generated';
 
-OpenAPI.BASE = import.meta.env.VITE_API_BASE_URL;
+// Use relative API paths when VITE_API_BASE_URL is not provided
+OpenAPI.BASE = import.meta.env.VITE_API_BASE_URL || '';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>


### PR DESCRIPTION
## Summary
- default OpenAPI base URL to empty string when VITE_API_BASE_URL is undefined

## Testing
- `npm test`
- `npm run build`
- `npm run e2e` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1181/chrome-linux/headless_shell)*
- `dotnet build -c Release`
- `dotnet test -c Release`


------
https://chatgpt.com/codex/tasks/task_e_689de72a89f8832584613961c271e19b