### PR TITLE
feat: namespace jobs under api

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Agents (Codex) Guide
 
-- Call `POST /v1/jobs?mode=immediate` with headers:
+- Call `POST /api/v1/jobs?mode=immediate` with headers:
   - `X-API-Key`
   - optional `X-Reasoning: think|no_think|auto`
 - Ensure a GGUF model is mounted at `/models` (compose does it).

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Il progetto integra:
 
 ## Job Queue
 
-- Passo 1: integrati **Hangfire** (MemoryStorage), **LiteDB** e **Rate Limiting** con endpoint `GET /v1/jobs` paginato.
-- Passo 2: aggiunto `POST /v1/jobs` per il submit (file base64/multipart), `GET /v1/jobs/{id}` e `DELETE /v1/jobs/{id}` con stato gestito solo da LiteDB e artefatti salvati su filesystem.
+- Passo 1: integrati **Hangfire** (MemoryStorage), **LiteDB** e **Rate Limiting** con endpoint `GET /api/v1/jobs` paginato.
+- Passo 2: aggiunto `POST /api/v1/jobs` per il submit (file base64/multipart), `GET /api/v1/jobs/{id}` e `DELETE /api/v1/jobs/{id}` con stato gestito solo da LiteDB e artefatti salvati su filesystem.
 
 ---
 
@@ -188,7 +188,7 @@ L’entrypoint scarica il **GGUF** con `curl` (Authorization: Bearer **HF\_TOKEN
 L'endpoint legacy `/api/process` è stato rimosso. Usa la coda lavori:
 
 ```bash
-curl -X POST 'http://localhost:5000/v1/jobs?mode=immediate' \
+curl -X POST 'http://localhost:5000/api/v1/jobs?mode=immediate' \
   -H 'X-API-Key: dev-secret-key-change-me' \
   -F 'file=@dataset/sample_invoice.pdf;type=application/pdf'
 ```

--- a/docs/job-queue.md
+++ b/docs/job-queue.md
@@ -28,7 +28,7 @@ Derived status is computed from the database status only:
 See `appsettings.json` section `JobQueue` for paths, rate limits and cleanup schedule. Dashboard auth can be enabled with `HangfireDashboardAuth`.
 
 ### Immediate mode
-Jobs can be executed inline by calling `POST /v1/jobs?mode=immediate` when `JobQueue.Immediate.Enabled=true`.
+Jobs can be executed inline by calling `POST /api/v1/jobs?mode=immediate` when `JobQueue.Immediate.Enabled=true`.
 The mode consumes the same concurrency gate as queued jobs and respects global backpressure, idempotency and dedupe rules.
 If capacity is unavailable the API returns `429 { error:"immediate_capacity" }` unless `FallbackToQueue` is true, in which case the job is enqueued and `202` is returned.
 Timeout for immediate execution is controlled by `JobQueue.Immediate.TimeoutSeconds` and should be lower than the ingress timeout.
@@ -37,13 +37,13 @@ The old `/api/v1/process` endpoint has been removed; all processing now flows th
 ## Examples
 ```
 # submit
-curl -X POST /v1/jobs -H "Content-Type: application/json" -d '{"fileBase64":"...","fileName":"a.pdf"}'
+curl -X POST /api/v1/jobs -H "Content-Type: application/json" -d '{"fileBase64":"...","fileName":"a.pdf"}'
 # list
-curl /v1/jobs?page=1&pageSize=20
+curl /api/v1/jobs?page=1&pageSize=20
 # get by id
-curl /v1/jobs/{id}
+curl /api/v1/jobs/{id}
 # cancel
-curl -X DELETE /v1/jobs/{id}
+curl -X DELETE /api/v1/jobs/{id}
 ```
 
 The dashboard is exposed at `/hangfire` when enabled. Protect it with basic auth credentials via configuration. Only non-executable files up to the configured size are accepted. Logs omit sensitive data and include structured properties for observability.

--- a/smoke/README.md
+++ b/smoke/README.md
@@ -4,4 +4,4 @@ Run:
 cd smoke
 ./smoke.sh
 ```
-Requires Docker. Place a GGUF model under `../models/` to exercise `/v1/jobs?mode=immediate` end-to-end.
+Requires Docker. Place a GGUF model under `../models/` to exercise `/api/v1/jobs?mode=immediate` end-to-end.

--- a/smoke/smoke.sh
+++ b/smoke/smoke.sh
@@ -16,7 +16,7 @@ cd "${proj_root}/deployment"
 docker compose up -d --build
 for i in {1..60}; do curl -sf "${API_URL}/health" >/dev/null && break || sleep 1; done
 if [ -f "${proj_root}/models/$(basename "${MODEL_PATH}")" ]; then
-  curl -s -X POST "${API_URL}/v1/jobs?mode=immediate" -H "X-API-Key: ${API_KEY}" -H "X-Reasoning: ${REASONING}" -F "file=@${here}/sample.png" | pretty | tee "${here}/process.json" >/dev/null
+  curl -s -X POST "${API_URL}/api/v1/jobs?mode=immediate" -H "X-API-Key: ${API_KEY}" -H "X-Reasoning: ${REASONING}" -F "file=@${here}/sample.png" | pretty | tee "${here}/process.json" >/dev/null
 else
   echo "NOTE: Model not found in ./models — skipping immediate job E2E"
 fi

--- a/tests/DocflowAi.Net.Api.Tests/BackpressureE2ETests.cs
+++ b/tests/DocflowAi.Net.Api.Tests/BackpressureE2ETests.cs
@@ -27,7 +27,7 @@ public class BackpressureE2ETests : IClassFixture<TempDirFixture>
         var dirsBefore = Directory.GetDirectories(factory.DataRootPath).Length;
         using (TestCorrelator.CreateContext())
         {
-            var resp = await client.PostAsJsonAsync("/v1/jobs", new { fileBase64 = Convert.ToBase64String(new byte[10]), fileName = "c.pdf" });
+            var resp = await client.PostAsJsonAsync("/api/v1/jobs", new { fileBase64 = Convert.ToBase64String(new byte[10]), fileName = "c.pdf" });
             resp.StatusCode.Should().Be(HttpStatusCode.TooManyRequests);
             resp.Headers.Should().ContainKey("Retry-After");
             Directory.GetDirectories(factory.DataRootPath).Length.Should().Be(dirsBefore);

--- a/tests/DocflowAi.Net.Api.Tests/DeleteJobTests.cs
+++ b/tests/DocflowAi.Net.Api.Tests/DeleteJobTests.cs
@@ -24,7 +24,7 @@ public class DeleteJobTests : IClassFixture<TempDirFixture>
         var store = factory.Services.GetRequiredService<IJobStore>();
         var job = LiteDbTestHelper.CreateJob(id, status, DateTimeOffset.UtcNow);
         store.Create(job);
-        var resp = await client.DeleteAsync($"/v1/jobs/{id}");
+        var resp = await client.DeleteAsync($"/api/v1/jobs/{id}");
         resp.StatusCode.Should().Be(HttpStatusCode.Accepted);
         var updated = LiteDbTestHelper.GetJob(factory.LiteDbPath, id);
         updated!.Status.Should().Be("Cancelled");
@@ -41,7 +41,7 @@ public class DeleteJobTests : IClassFixture<TempDirFixture>
         var store = factory.Services.GetRequiredService<IJobStore>();
         var job = LiteDbTestHelper.CreateJob(id, status, DateTimeOffset.UtcNow);
         store.Create(job);
-        var resp = await client.DeleteAsync($"/v1/jobs/{id}");
+        var resp = await client.DeleteAsync($"/api/v1/jobs/{id}");
         resp.StatusCode.Should().Be(HttpStatusCode.Conflict);
     }
 }

--- a/tests/DocflowAi.Net.Api.Tests/GetJobByIdTests.cs
+++ b/tests/DocflowAi.Net.Api.Tests/GetJobByIdTests.cs
@@ -36,7 +36,7 @@ public class GetJobByIdTests : IClassFixture<TempDirFixture>
             Metrics = new JobDocument.MetricsInfo()
         };
         store.Create(job);
-        var resp = await client.GetAsync($"/v1/jobs/{id}");
+        var resp = await client.GetAsync($"/api/v1/jobs/{id}");
         resp.StatusCode.Should().Be(HttpStatusCode.OK);
         var json = await resp.Content.ReadFromJsonAsync<JsonElement>();
         json.GetProperty("status").GetString().Should().Be("Running");
@@ -50,7 +50,7 @@ public class GetJobByIdTests : IClassFixture<TempDirFixture>
     {
         using var factory = new TestWebAppFactory(_fx.RootPath);
         var client = factory.CreateClient();
-        var resp = await client.GetAsync($"/v1/jobs/{Guid.NewGuid()}");
+        var resp = await client.GetAsync($"/api/v1/jobs/{Guid.NewGuid()}");
         resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 }

--- a/tests/DocflowAi.Net.Api.Tests/IdempotencyAndDedupeTests.cs
+++ b/tests/DocflowAi.Net.Api.Tests/IdempotencyAndDedupeTests.cs
@@ -21,13 +21,13 @@ public class IdempotencyAndDedupeTests : IClassFixture<TempDirFixture>
         new Random(1).NextBytes(bytes);
         var base64 = Convert.ToBase64String(bytes);
 
-        var req1 = new HttpRequestMessage(HttpMethod.Post, "/v1/jobs") { Content = JsonContent.Create(new { fileBase64 = base64, fileName = "a.pdf" }) };
+        var req1 = new HttpRequestMessage(HttpMethod.Post, "/api/v1/jobs") { Content = JsonContent.Create(new { fileBase64 = base64, fileName = "a.pdf" }) };
         req1.Headers.Add("Idempotency-Key", "K1");
         var resp1 = await client.SendAsync(req1);
         resp1.StatusCode.Should().Be(HttpStatusCode.Accepted);
         var id1 = (await resp1.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("job_id").GetGuid();
 
-        var req2 = new HttpRequestMessage(HttpMethod.Post, "/v1/jobs") { Content = JsonContent.Create(new { fileBase64 = base64, fileName = "a.pdf" }) };
+        var req2 = new HttpRequestMessage(HttpMethod.Post, "/api/v1/jobs") { Content = JsonContent.Create(new { fileBase64 = base64, fileName = "a.pdf" }) };
         req2.Headers.Add("Idempotency-Key", "K1");
         var resp2 = await client.SendAsync(req2);
         resp2.StatusCode.Should().Be(HttpStatusCode.Accepted);
@@ -45,11 +45,11 @@ public class IdempotencyAndDedupeTests : IClassFixture<TempDirFixture>
         new Random(2).NextBytes(bytes);
         var base64 = Convert.ToBase64String(bytes);
 
-        var resp1 = await client.PostAsJsonAsync("/v1/jobs", new { fileBase64 = base64, fileName = "b.pdf" });
+        var resp1 = await client.PostAsJsonAsync("/api/v1/jobs", new { fileBase64 = base64, fileName = "b.pdf" });
         resp1.StatusCode.Should().Be(HttpStatusCode.Accepted);
         var id1 = (await resp1.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("job_id").GetGuid();
 
-        var resp2 = await client.PostAsJsonAsync("/v1/jobs", new { fileBase64 = base64, fileName = "b.pdf" });
+        var resp2 = await client.PostAsJsonAsync("/api/v1/jobs", new { fileBase64 = base64, fileName = "b.pdf" });
         resp2.StatusCode.Should().Be(HttpStatusCode.Accepted);
         var id2 = (await resp2.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("job_id").GetGuid();
         id2.Should().Be(id1);
@@ -65,13 +65,13 @@ public class IdempotencyAndDedupeTests : IClassFixture<TempDirFixture>
         new Random(3).NextBytes(bytes);
         var base64 = Convert.ToBase64String(bytes);
 
-        var req1 = new HttpRequestMessage(HttpMethod.Post, "/v1/jobs?mode=immediate") { Content = JsonContent.Create(new { fileBase64 = base64, fileName = "c.pdf" }) };
+        var req1 = new HttpRequestMessage(HttpMethod.Post, "/api/v1/jobs?mode=immediate") { Content = JsonContent.Create(new { fileBase64 = base64, fileName = "c.pdf" }) };
         req1.Headers.Add("Idempotency-Key", "K2");
         var resp1 = await client.SendAsync(req1);
         resp1.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
         var id1 = (await resp1.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("job_id").GetGuid();
 
-        var req2 = new HttpRequestMessage(HttpMethod.Post, "/v1/jobs?mode=immediate") { Content = JsonContent.Create(new { fileBase64 = base64, fileName = "c.pdf" }) };
+        var req2 = new HttpRequestMessage(HttpMethod.Post, "/api/v1/jobs?mode=immediate") { Content = JsonContent.Create(new { fileBase64 = base64, fileName = "c.pdf" }) };
         req2.Headers.Add("Idempotency-Key", "K2");
         var resp2 = await client.SendAsync(req2);
         resp2.StatusCode.Should().Be(System.Net.HttpStatusCode.Accepted);
@@ -88,11 +88,11 @@ public class IdempotencyAndDedupeTests : IClassFixture<TempDirFixture>
         new Random(4).NextBytes(bytes);
         var base64 = Convert.ToBase64String(bytes);
 
-        var resp1 = await client.PostAsJsonAsync("/v1/jobs?mode=immediate", new { fileBase64 = base64, fileName = "d.pdf" });
+        var resp1 = await client.PostAsJsonAsync("/api/v1/jobs?mode=immediate", new { fileBase64 = base64, fileName = "d.pdf" });
         resp1.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
         var id1 = (await resp1.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("job_id").GetGuid();
 
-        var resp2 = await client.PostAsJsonAsync("/v1/jobs?mode=immediate", new { fileBase64 = base64, fileName = "d.pdf" });
+        var resp2 = await client.PostAsJsonAsync("/api/v1/jobs?mode=immediate", new { fileBase64 = base64, fileName = "d.pdf" });
         resp2.StatusCode.Should().Be(System.Net.HttpStatusCode.Accepted);
         var id2 = (await resp2.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("job_id").GetGuid();
         id2.Should().Be(id1);

--- a/tests/DocflowAi.Net.Api.Tests/ImmediateBackpressureTests.cs
+++ b/tests/DocflowAi.Net.Api.Tests/ImmediateBackpressureTests.cs
@@ -24,7 +24,7 @@ public class ImmediateBackpressureTests : IClassFixture<TempDirFixture>
         var payload = new { fileBase64 = Convert.ToBase64String(new byte[]{1}), fileName = "a.pdf" };
         using (TestCorrelator.CreateContext())
         {
-            var resp = await client.PostAsJsonAsync("/v1/jobs?mode=immediate", payload);
+            var resp = await client.PostAsJsonAsync("/api/v1/jobs?mode=immediate", payload);
             resp.StatusCode.Should().Be(System.Net.HttpStatusCode.TooManyRequests);
             resp.Headers.Should().ContainKey("Retry-After");
             (await resp.Content.ReadAsStringAsync()).Should().Contain("queue_full");

--- a/tests/DocflowAi.Net.Api.Tests/ImmediateCapacityAndFallbackTests.cs
+++ b/tests/DocflowAi.Net.Api.Tests/ImmediateCapacityAndFallbackTests.cs
@@ -20,10 +20,10 @@ public class ImmediateCapacityAndFallbackTests : IClassFixture<TempDirFixture>
         factory.Fake.CurrentMode = FakeProcessService.Mode.Slow;
         var client = factory.CreateClient();
         var payload = new { fileBase64 = Convert.ToBase64String(new byte[]{1}), fileName = "a.pdf" };
-        var first = client.PostAsJsonAsync("/v1/jobs?mode=immediate", payload); // running
+        var first = client.PostAsJsonAsync("/api/v1/jobs?mode=immediate", payload); // running
         await Task.Delay(100); // ensure started
         var secondPayload = new { fileBase64 = Convert.ToBase64String(new byte[]{2}), fileName = "b.pdf" };
-        var second = await client.PostAsJsonAsync("/v1/jobs?mode=immediate", secondPayload);
+        var second = await client.PostAsJsonAsync("/api/v1/jobs?mode=immediate", secondPayload);
         second.StatusCode.Should().Be(System.Net.HttpStatusCode.TooManyRequests);
         second.Headers.Should().ContainKey("Retry-After");
         (await second.Content.ReadAsStringAsync()).Should().Contain("immediate_capacity");
@@ -37,10 +37,10 @@ public class ImmediateCapacityAndFallbackTests : IClassFixture<TempDirFixture>
         factory.Fake.CurrentMode = FakeProcessService.Mode.Slow;
         var client = factory.CreateClient();
         var payload = new { fileBase64 = Convert.ToBase64String(new byte[]{1}), fileName = "a.pdf" };
-        var first = client.PostAsJsonAsync("/v1/jobs?mode=immediate", payload);
+        var first = client.PostAsJsonAsync("/api/v1/jobs?mode=immediate", payload);
         await Task.Delay(100);
         var secondPayload = new { fileBase64 = Convert.ToBase64String(new byte[]{2}), fileName = "b.pdf" };
-        var second = await client.PostAsJsonAsync("/v1/jobs?mode=immediate", secondPayload);
+        var second = await client.PostAsJsonAsync("/api/v1/jobs?mode=immediate", secondPayload);
         second.StatusCode.Should().Be(System.Net.HttpStatusCode.Accepted);
         var body = await second.Content.ReadFromJsonAsync<JsonElement>();
         var id = body.GetProperty("job_id").GetGuid();

--- a/tests/DocflowAi.Net.Api.Tests/ImmediateJobCancelTests.cs
+++ b/tests/DocflowAi.Net.Api.Tests/ImmediateJobCancelTests.cs
@@ -23,7 +23,7 @@ public class ImmediateJobCancelTests : IClassFixture<TempDirFixture>
         using var cts = new CancellationTokenSource();
         using (TestCorrelator.CreateContext())
         {
-            var post = client.PostAsJsonAsync("/v1/jobs?mode=immediate", payload, cts.Token);
+            var post = client.PostAsJsonAsync("/api/v1/jobs?mode=immediate", payload, cts.Token);
             await Task.Delay(100);
             cts.Cancel();
             try { await post; } catch (TaskCanceledException) { }

--- a/tests/DocflowAi.Net.Api.Tests/ImmediateJobFailAndTimeoutTests.cs
+++ b/tests/DocflowAi.Net.Api.Tests/ImmediateJobFailAndTimeoutTests.cs
@@ -20,7 +20,7 @@ public class ImmediateJobFailAndTimeoutTests : IClassFixture<TempDirFixture>
         factory.Fake.CurrentMode = FakeProcessService.Mode.Fail;
         var client = factory.CreateClient();
         var payload = new { fileBase64 = Convert.ToBase64String(new byte[]{1}), fileName = "a.pdf" };
-        var res = await client.PostAsJsonAsync("/v1/jobs?mode=immediate", payload);
+        var res = await client.PostAsJsonAsync("/api/v1/jobs?mode=immediate", payload);
         res.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
         var body = await res.Content.ReadFromJsonAsync<JsonElement>();
         var id = body.GetProperty("job_id").GetGuid();
@@ -37,7 +37,7 @@ public class ImmediateJobFailAndTimeoutTests : IClassFixture<TempDirFixture>
         factory.Fake.CurrentMode = FakeProcessService.Mode.Slow;
         var client = factory.CreateClient();
         var payload = new { fileBase64 = Convert.ToBase64String(new byte[]{1}), fileName = "a.pdf" };
-        var res = await client.PostAsJsonAsync("/v1/jobs?mode=immediate", payload);
+        var res = await client.PostAsJsonAsync("/api/v1/jobs?mode=immediate", payload);
         res.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
         var body = await res.Content.ReadFromJsonAsync<JsonElement>();
         var id = body.GetProperty("job_id").GetGuid();

--- a/tests/DocflowAi.Net.Api.Tests/ImmediateJobSuccessTests.cs
+++ b/tests/DocflowAi.Net.Api.Tests/ImmediateJobSuccessTests.cs
@@ -23,7 +23,7 @@ public class ImmediateJobSuccessTests : IClassFixture<TempDirFixture>
         var client = factory.CreateClient();
         var pdf = new byte[]{1,2,3,4};
         var payload = new { fileBase64 = Convert.ToBase64String(pdf), fileName = "a.pdf" };
-        var res = await client.PostAsJsonAsync("/v1/jobs?mode=immediate", payload);
+        var res = await client.PostAsJsonAsync("/api/v1/jobs?mode=immediate", payload);
         res.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
         var body = await res.Content.ReadFromJsonAsync<JsonElement>();
         var id = body.GetProperty("job_id").GetGuid();

--- a/tests/DocflowAi.Net.Api.Tests/ImmediateLoggingTests.cs
+++ b/tests/DocflowAi.Net.Api.Tests/ImmediateLoggingTests.cs
@@ -20,7 +20,7 @@ public class ImmediateLoggingTests : IClassFixture<TempDirFixture>
         using (TestCorrelator.CreateContext())
         {
             factory.Fake.CurrentMode = FakeProcessService.Mode.Success;
-            var resp = await client.PostAsJsonAsync("/v1/jobs?mode=immediate", payload1);
+            var resp = await client.PostAsJsonAsync("/api/v1/jobs?mode=immediate", payload1);
             resp.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
             TestCorrelator.GetLogEventsFromCurrentContext();
         }
@@ -28,7 +28,7 @@ public class ImmediateLoggingTests : IClassFixture<TempDirFixture>
         {
             factory.Fake.CurrentMode = FakeProcessService.Mode.Fail;
             var payload2 = new { fileBase64 = Convert.ToBase64String(new byte[]{2}), fileName = "b.pdf" };
-            var resp = await client.PostAsJsonAsync("/v1/jobs?mode=immediate", payload2);
+            var resp = await client.PostAsJsonAsync("/api/v1/jobs?mode=immediate", payload2);
             resp.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
             TestCorrelator.GetLogEventsFromCurrentContext();
         }

--- a/tests/DocflowAi.Net.Api.Tests/JobsListEndpointTests.cs
+++ b/tests/DocflowAi.Net.Api.Tests/JobsListEndpointTests.cs
@@ -23,7 +23,7 @@ public class JobsListEndpointTests : IClassFixture<TempDirFixture>
     {
         using var factory = new TestWebAppFactory(_fixture.RootPath);
         var client = factory.CreateClient();
-        var resp = await client.GetAsync("/v1/jobs");
+        var resp = await client.GetAsync("/api/v1/jobs");
         resp.StatusCode.Should().Be(HttpStatusCode.OK);
         var data = await resp.Content.ReadFromJsonAsync<JobListResponse>();
         data!.page.Should().Be(1);
@@ -43,17 +43,17 @@ public class JobsListEndpointTests : IClassFixture<TempDirFixture>
             .ToList();
         LiteDbTestHelper.SeedJobs(db, jobs);
 
-        var r1 = await client.GetFromJsonAsync<JobListResponse>("/v1/jobs?page=1&pageSize=10");
+        var r1 = await client.GetFromJsonAsync<JobListResponse>("/api/v1/jobs?page=1&pageSize=10");
         r1!.total.Should().Be(35);
         r1.items.Should().HaveCount(10);
         r1.items[0].id.Should().Be(jobs[34].Id);
         r1.items[9].id.Should().Be(jobs[25].Id);
 
-        var r2 = await client.GetFromJsonAsync<JobListResponse>("/v1/jobs?page=2&pageSize=10");
+        var r2 = await client.GetFromJsonAsync<JobListResponse>("/api/v1/jobs?page=2&pageSize=10");
         r2!.items[0].id.Should().Be(jobs[24].Id);
         r2.items[9].id.Should().Be(jobs[15].Id);
 
-        var r4 = await client.GetFromJsonAsync<JobListResponse>("/v1/jobs?page=4&pageSize=10");
+        var r4 = await client.GetFromJsonAsync<JobListResponse>("/api/v1/jobs?page=4&pageSize=10");
         r4!.items.Should().HaveCount(5);
         r4.items[0].id.Should().Be(jobs[4].Id);
         r4.items[4].id.Should().Be(jobs[0].Id);
@@ -64,7 +64,7 @@ public class JobsListEndpointTests : IClassFixture<TempDirFixture>
     {
         using var factory = new TestWebAppFactory(_fixture.RootPath);
         var client = factory.CreateClient();
-        var bad = await client.GetAsync("/v1/jobs?page=0");
+        var bad = await client.GetAsync("/api/v1/jobs?page=0");
         bad.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         var err = await bad.Content.ReadFromJsonAsync<ErrorResponse>();
         err!.error.Should().Be("bad_request");
@@ -74,7 +74,7 @@ public class JobsListEndpointTests : IClassFixture<TempDirFixture>
             .Select(i => LiteDbTestHelper.CreateJob(Guid.NewGuid(), "Queued", _baseTime.AddMinutes(i)))
             .ToList();
         LiteDbTestHelper.SeedJobs(db, jobs);
-        var resp = await client.GetFromJsonAsync<JobListResponse>("/v1/jobs?page=1&pageSize=500");
+        var resp = await client.GetFromJsonAsync<JobListResponse>("/api/v1/jobs?page=1&pageSize=500");
         resp!.pageSize.Should().Be(100);
         resp.items.Should().HaveCount(100);
     }
@@ -88,7 +88,7 @@ public class JobsListEndpointTests : IClassFixture<TempDirFixture>
         var statuses = new[] { "Queued", "Running", "Succeeded", "Failed", "Cancelled" };
         var jobs = statuses.Select((s,i) => LiteDbTestHelper.CreateJob(Guid.NewGuid(), s, _baseTime.AddMinutes(i))).ToList();
         LiteDbTestHelper.SeedJobs(db, jobs);
-        var resp = await client.GetFromJsonAsync<JobListResponse>("/v1/jobs?page=1&pageSize=10");
+        var resp = await client.GetFromJsonAsync<JobListResponse>("/api/v1/jobs?page=1&pageSize=10");
         resp!.items.Should().HaveCount(5);
         var map = new Dictionary<string,string>{
             ["Queued"]="Pending",

--- a/tests/DocflowAi.Net.Api.Tests/RateLimitSubmitTests.cs
+++ b/tests/DocflowAi.Net.Api.Tests/RateLimitSubmitTests.cs
@@ -19,10 +19,10 @@ public class RateLimitSubmitTests : IClassFixture<TempDirFixture>
         using var factory = new TestWebAppFactory(_fx.RootPath, permit:1, windowSeconds:1);
         var client = factory.CreateClient();
         var body = new { fileBase64 = Convert.ToBase64String(new byte[10]), fileName = "a.pdf" };
-        await client.PostAsJsonAsync("/v1/jobs", body);
+        await client.PostAsJsonAsync("/api/v1/jobs", body);
         using (TestCorrelator.CreateContext())
         {
-            var resp = await client.PostAsJsonAsync("/v1/jobs", body);
+            var resp = await client.PostAsJsonAsync("/api/v1/jobs", body);
             resp.StatusCode.Should().Be(HttpStatusCode.TooManyRequests);
             resp.Headers.Should().ContainKey("Retry-After");
         }

--- a/tests/DocflowAi.Net.Api.Tests/RateLimitTests.cs
+++ b/tests/DocflowAi.Net.Api.Tests/RateLimitTests.cs
@@ -14,9 +14,9 @@ public class RateLimitTests : IClassFixture<TempDirFixture>
     {
         using var factory = new TestWebAppFactory(_fixture.RootPath, permit:2, windowSeconds:1);
         var client = factory.CreateClient();
-        await client.GetAsync("/v1/jobs");
-        await client.GetAsync("/v1/jobs");
-        var resp = await client.GetAsync("/v1/jobs");
+        await client.GetAsync("/api/v1/jobs");
+        await client.GetAsync("/api/v1/jobs");
+        var resp = await client.GetAsync("/api/v1/jobs");
         resp.StatusCode.Should().Be(HttpStatusCode.TooManyRequests);
         var json = await resp.Content.ReadFromJsonAsync<RateLimitResponse>();
         json!.error.Should().Be("rate_limited");

--- a/tests/DocflowAi.Net.Api.Tests/SubmitEndpointTests.cs
+++ b/tests/DocflowAi.Net.Api.Tests/SubmitEndpointTests.cs
@@ -23,7 +23,7 @@ public class SubmitEndpointTests : IClassFixture<TempDirFixture>
         new Random(1).NextBytes(bytes);
         var base64 = Convert.ToBase64String(bytes);
 
-        var resp = await client.PostAsJsonAsync("/v1/jobs", new { fileBase64 = base64, fileName = "input.pdf", prompt = "hi", fields = "{}" });
+        var resp = await client.PostAsJsonAsync("/api/v1/jobs", new { fileBase64 = base64, fileName = "input.pdf", prompt = "hi", fields = "{}" });
         resp.StatusCode.Should().Be(HttpStatusCode.Accepted);
         var json = await resp.Content.ReadFromJsonAsync<JsonElement>();
         var id = json.GetProperty("job_id").GetGuid();

--- a/tests/DocflowAi.Net.Api.Tests/SwaggerSpecTests.cs
+++ b/tests/DocflowAi.Net.Api.Tests/SwaggerSpecTests.cs
@@ -21,11 +21,11 @@ public class SwaggerSpecTests : IClassFixture<TempDirFixture>
         var json = await client.GetStringAsync("/swagger/v1/swagger.json");
         using var doc = JsonDocument.Parse(json);
         doc.RootElement.GetProperty("paths").EnumerateObject().Select(p => p.Name)
-            .Should().Contain("/v1/jobs");
+            .Should().Contain("/api/v1/jobs");
         doc.RootElement.GetProperty("paths").EnumerateObject().Select(p => p.Name)
             .Should().NotContain("/process");
 
-        var post = doc.RootElement.GetProperty("paths").GetProperty("/v1/jobs").GetProperty("post");
+        var post = doc.RootElement.GetProperty("paths").GetProperty("/api/v1/jobs").GetProperty("post");
         var modeParam = post.GetProperty("parameters").EnumerateArray().First(p => p.GetProperty("name").GetString()=="mode");
         modeParam.GetProperty("schema").GetProperty("enum").EnumerateArray().Select(e=>e.GetString())
             .Should().BeEquivalentTo(new[]{"queued","immediate"});

--- a/tests/DocflowAi.Net.Api.Tests/ValidationTests.cs
+++ b/tests/DocflowAi.Net.Api.Tests/ValidationTests.cs
@@ -20,7 +20,7 @@ public class ValidationTests : IClassFixture<TempDirFixture>
         await using var factory = new TestWebAppFactory(_fx.RootPath, uploadLimitMb:1);
         var client = factory.CreateClient();
         var big = new byte[2 * 1024 * 1024];
-        var resp = await client.PostAsJsonAsync("/v1/jobs", new { fileBase64 = Convert.ToBase64String(big), fileName = "a.pdf" });
+        var resp = await client.PostAsJsonAsync("/api/v1/jobs", new { fileBase64 = Convert.ToBase64String(big), fileName = "a.pdf" });
         resp.StatusCode.Should().Be(HttpStatusCode.RequestEntityTooLarge);
         Directory.GetDirectories(factory.DataRootPath).Should().BeEmpty();
         var store = factory.Services.GetRequiredService<IJobStore>();
@@ -33,7 +33,7 @@ public class ValidationTests : IClassFixture<TempDirFixture>
         await using var factory = new TestWebAppFactory(_fx.RootPath);
         var client = factory.CreateClient();
         var bytes = new byte[10];
-        var resp = await client.PostAsJsonAsync("/v1/jobs", new { fileBase64 = Convert.ToBase64String(bytes), fileName = "a.exe" });
+        var resp = await client.PostAsJsonAsync("/api/v1/jobs", new { fileBase64 = Convert.ToBase64String(bytes), fileName = "a.exe" });
         resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         Directory.GetDirectories(factory.DataRootPath).Should().BeEmpty();
         var store = factory.Services.GetRequiredService<IJobStore>();


### PR DESCRIPTION
## Summary
- scope job queue under `/api/v1`
- update tests and docs for `/api/v1/jobs`

## Testing
- `rg -n -i 'pytest|:8000|sidecar|MarkitdownException|MARKITDOWN_URL|PY_MARKITDOWN_ENABLED' -g '!AGENTS.md'`
- `dotnet build -c Release`
- `dotnet test -c Release`
- `npm test -- --run`
- `npm run build`
- `npm run e2e` *(fails: host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_689de9b70ad483259058f48d0894ab25