### PR TITLE
fix: handle missing health reasons

### DIFF
--- a/frontend/src/pages/HealthPage.tsx
+++ b/frontend/src/pages/HealthPage.tsx
@@ -26,15 +26,18 @@ export default function HealthPage() {
     load();
   }, []);
 
+  const readyReasons = ready?.reasons ?? [];
+  const liveReasons = live?.reasons ?? [];
+
   return (
     <div>
       <h2>Health</h2>
       <HealthBadge />
       <Button onClick={load}>Riprova</Button>
       <h3>Ready: {ready?.status}</h3>
-      <ul>{ready?.reasons.map((r) => (<li key={r}>{r}</li>))}</ul>
+      <ul>{readyReasons.map((r) => (<li key={r}>{r}</li>))}</ul>
       <h3>Live: {live?.status}</h3>
-      <ul>{live?.reasons.map((r) => (<li key={r}>{r}</li>))}</ul>
+      <ul>{liveReasons.map((r) => (<li key={r}>{r}</li>))}</ul>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- avoid frontend errors when health API omits reasons

## Testing
- `rg -n -i 'pytest|:8000|sidecar|MarkitdownException|MARKITDOWN_URL|PY_MARKITDOWN_ENABLED'`
- `npm test -- --run`
- `npm run build`
- `npm run e2e` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1181/chrome-linux/headless_shell)*
- `dotnet build -c Release`
- `dotnet test -c Release`

------
https://chatgpt.com/codex/tasks/task_e_689dee6be3e08325b77a98b21ed869e6