### PR TITLE
Use OpenAPI client for REST calls

### DIFF
--- a/frontend/src/api/fetcher.ts
+++ b/frontend/src/api/fetcher.ts
@@ -18,8 +18,7 @@ export class HttpError extends Error {
 }
 
 const base = import.meta.env.VITE_API_BASE_URL || '';
-const normalized = base.replace(/\/$/, '');
-const BASE_URL = normalized.endsWith('/api/v1') ? normalized : `${normalized}/api/v1`;
+const BASE_URL = base.replace(/\/$/, '');
 
 export async function fetcher(input: string, init: RequestInit): Promise<Response> {
   const url = input.startsWith('http') ? input : `${BASE_URL}${input}`;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -7,10 +7,8 @@ import App from './App';
 import { HashRouter } from 'react-router-dom';
 import { OpenAPI } from './generated';
 
-// Ensure API calls are prefixed with /api/v1
 const base = import.meta.env.VITE_API_BASE_URL || '';
-const normalized = base.replace(/\/$/, '');
-OpenAPI.BASE = normalized.endsWith('/api/v1') ? normalized : `${normalized}/api/v1`;
+OpenAPI.BASE = base.replace(/\/$/, '');
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/frontend/src/pages/HealthPage.tsx
+++ b/frontend/src/pages/HealthPage.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from 'react';
 import { Button } from 'antd';
 import HealthBadge from '../components/HealthBadge';
 import { DefaultService, type HealthResponse } from '../generated';
-import { fetcher } from '../api/fetcher';
 
 export default function HealthPage() {
   const [ready, setReady] = useState<HealthResponse | null>(null);
@@ -15,8 +14,7 @@ export default function HealthPage() {
       setReady(null);
     }
     try {
-      const res = await fetcher('/health/live', { method: 'GET' });
-      setLive(await res.json());
+      setLive(await DefaultService.getHealthLive());
     } catch {
       setLive(null);
     }

--- a/frontend/src/pages/JobNew.test.tsx
+++ b/frontend/src/pages/JobNew.test.tsx
@@ -38,15 +38,21 @@ test('validateFile', () => {
 test('submitFormData branches', async () => {
   const form = buildFormData(new File(['a'], 'a.txt'), 'p', '{}');
   (fetcher as any).mockResolvedValueOnce(
-    new Response(JSON.stringify({ id: '1', status: 'Succeeded' }), { status: 200 })
+    new Response(JSON.stringify({ id: '1', status: 'Succeeded' }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
   );
   let res = await submitFormData(form, true);
-  expect(res.status).toBe(200);
+  expect(res).toMatchObject({ id: '1', status: 'Succeeded' });
   (fetcher as any).mockResolvedValueOnce(
-    new Response(JSON.stringify({ id: '2' }), { status: 202 })
+    new Response(JSON.stringify({ id: '2', status: 'Pending' }), {
+      status: 202,
+      headers: { 'Content-Type': 'application/json' },
+    })
   );
   res = await submitFormData(form, false);
-  expect(res.status).toBe(202);
+  expect(res).toMatchObject({ id: '2', status: 'Pending' });
   (fetcher as any).mockRejectedValueOnce(
     new HttpError(429, { errorCode: 'immediate_capacity' }, 5)
   );


### PR DESCRIPTION
## Summary
- avoid double `/api/v1` prefix by trusting VITE_API_BASE_URL
- route health checks and job submission through generated OpenAPI client
- update tests for new request flow

## Testing
- `rg -n -i 'pytest|:8000|sidecar|MarkitdownException|MARKITDOWN_URL|PY_MARKITDOWN_ENABLED' --glob '!*AGENTS.md'`
- `dotnet build -c Release`
- `dotnet test -c Release`
- `cd frontend && npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_689df4c306f88325aff7a5f401ff60e6