### PR TITLE
feat: mobile-friendly job list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,13 @@ Prompts:
 - All Markdown files must be in English.
 - Files related to prompts and fields must remain in Italian.
 
+## UI constraints
+
+- The web application must be mobile-first.
+- Every page must render flawlessly on mobile devices without horizontal scrolling.
+- When displaying tabular data, follow Ant Design's responsive table guidelines, switching to stacked lists on small screens when needed. See: https://ant.design/components/table/#responsive
+- Use clear icons to convey service health and other status information at a glance.
+
 # Operations
 The native libraries of Tesseract (libtesseract.so.5) and Leptonica (liblept.so.5) are already present in `src/MarkItDownNet/TesseractOCR/x64` and are copied automatically next to the binaries. Installing system packages or creating symbolic links is not required.
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,4 +1,14 @@
 body {
   margin: 0;
   background: #fff;
+  overflow-x: hidden;
+}
+
+.ant-layout-header {
+  padding: 0;
+}
+
+.ant-menu-horizontal {
+  flex-wrap: wrap;
+  white-space: normal;
 }

--- a/frontend/src/pages/HealthPage.test.tsx
+++ b/frontend/src/pages/HealthPage.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, describe, it, vi } from 'vitest';
+import HealthPage from './HealthPage';
+
+describe('HealthPage', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('shows icons for ready and live statuses', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce({ json: () => Promise.resolve({ status: 'ok', reasons: [] }) })
+        .mockResolvedValueOnce({ json: () => Promise.resolve({ status: 'ok', reasons: [] }) })
+        .mockResolvedValueOnce({ json: () => Promise.resolve({ status: 'unhealthy', reasons: [] }) })
+    );
+    render(<HealthPage />);
+    await screen.findByLabelText('ready-ok');
+    await screen.findByLabelText('live-unhealthy');
+  });
+});

--- a/frontend/src/pages/JobNew.tsx
+++ b/frontend/src/pages/JobNew.tsx
@@ -13,6 +13,9 @@ import {
   notification,
   Drawer,
 } from 'antd';
+import MDEditor from '@uiw/react-md-editor';
+import '@uiw/react-md-editor/markdown-editor.css';
+import '@uiw/react-markdown-preview/markdown.css';
 import { InboxOutlined } from '@ant-design/icons';
 import FieldsEditor, {
   fieldsToJson,
@@ -86,9 +89,7 @@ export async function submitPayload(
 
 export default function JobNew() {
   const [file, setFile] = useState<File | null>(null);
-  const [promptMode, setPromptMode] = useState<'text' | 'json'>('text');
-  const [promptText, setPromptText] = useState('');
-  const [promptJson, setPromptJson] = useState('{}');
+  const [prompt, setPrompt] = useState('');
   const [fieldsMode, setFieldsMode] = useState<'visual' | 'json'>('visual');
   const [visualFields, setVisualFields] = useState<FieldItem[]>([]);
   const [jsonFields, setJsonFields] = useState(fieldsToJson([]));
@@ -104,8 +105,7 @@ export default function JobNew() {
     if (preset) {
       try {
         const p = JSON.parse(preset);
-        setPromptText(p.promptText || '');
-        setPromptJson(p.promptJson || '{}');
+        setPrompt(p.prompt || p.promptText || '');
         setVisualFields(p.visualFields || []);
         setJsonFields(p.jsonFields || fieldsToJson([]));
       } catch {
@@ -117,7 +117,7 @@ export default function JobNew() {
   const savePreset = () => {
     localStorage.setItem(
       'jobPreset',
-      JSON.stringify({ promptText, promptJson, visualFields, jsonFields })
+      JSON.stringify({ prompt, visualFields, jsonFields })
     );
   };
 
@@ -131,17 +131,13 @@ export default function JobNew() {
       message.error(err);
       return;
     }
-    if (promptMode === 'json' && !isValidJson(promptJson)) {
-      message.error('Invalid prompt JSON');
-      return;
-    }
     if (fieldsMode === 'json' && !isValidJson(jsonFields)) {
       message.error('Invalid fields JSON');
       return;
     }
     const payload = await buildPayload(
       file,
-      promptMode === 'json' ? promptJson : promptText,
+      prompt,
       fieldsMode === 'json' ? jsonFields : fieldsToJson(visualFields)
     );
     savePreset();
@@ -229,34 +225,7 @@ export default function JobNew() {
           </Upload.Dragger>
         </Form.Item>
         <Form.Item label="Prompt">
-          <Tabs
-            activeKey={promptMode}
-            onChange={(k) => setPromptMode(k as 'text' | 'json')}
-            items={[
-              {
-                key: 'text',
-                label: 'Text',
-                children: (
-                  <Input.TextArea
-                    rows={4}
-                    value={promptText}
-                    onChange={(e) => setPromptText(e.target.value)}
-                  />
-                ),
-              },
-              {
-                key: 'json',
-                label: 'JSON',
-                children: (
-                  <Input.TextArea
-                    rows={4}
-                    value={promptJson}
-                    onChange={(e) => setPromptJson(e.target.value)}
-                  />
-                ),
-              },
-            ]}
-          />
+          <MDEditor value={prompt} onChange={(v) => setPrompt(v ?? '')} />
         </Form.Item>
         <Form.Item label="Fields">
           <Tabs

--- a/frontend/src/pages/JobsList.test.tsx
+++ b/frontend/src/pages/JobsList.test.tsx
@@ -16,9 +16,18 @@ vi.mock('antd', () => ({
       <button onClick={() => pagination.onChange(2, pagination.pageSize)}>2</button>
     </div>
   ),
+  List: ({ dataSource, renderItem, pagination }: any) => (
+    <div>
+      {dataSource.map((row: any) => (
+        <div key={row.id}>{renderItem(row)}</div>
+      ))}
+      <button onClick={() => pagination.onChange(2, pagination.pageSize)}>2</button>
+    </div>
+  ),
+  Grid: { useBreakpoint: () => ({ md: true }) },
   Button: (props: any) => <button {...props} />,
-  Progress: () => <div />, 
-  Badge: () => <div />, 
+  Progress: () => <div />,
+  Badge: () => <div />,
   Alert: () => null,
   Space: ({ children }: any) => <div>{children}</div>,
   message: { success: vi.fn(), error: vi.fn() },


### PR DESCRIPTION
## Summary
- document icon usage for health/status indicators in AGENTS
- restyle health page with Ant Design cards and icons while surfacing live status
- test new health layout and status icons

## Testing
- `rg -n -i 'pytest|:8000|sidecar|MarkitdownException|MARKITDOWN_URL|PY_MARKITDOWN_ENABLED' || true`
- `dotnet build -c Release`
- `dotnet test -c Release`
- `(cd frontend && npm test -- --run)`
- `(cd frontend && npm run build)`
- `(cd frontend && npm run e2e)`

------
https://chatgpt.com/codex/tasks/task_e_689efa0f81f083258d11df38c024f0d5