### PR TITLE
feat: enhance health indicators and live check

### DIFF
--- a/frontend/src/components/HealthBadge.test.tsx
+++ b/frontend/src/components/HealthBadge.test.tsx
@@ -10,18 +10,18 @@ describe('HealthBadge', () => {
   it('shows green on ok', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ json: () => Promise.resolve({ status: 'ok', reasons: [] }) }));
     render(<HealthBadge />);
-    await screen.findAllByText('Health');
+    await screen.findByLabelText('health-ok');
   });
 
   it('shows red on unhealthy', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ json: () => Promise.resolve({ status: 'unhealthy', reasons: ['bad'] }) }));
     render(<HealthBadge />);
-    await screen.findAllByText('Health');
+    await screen.findByLabelText('health-unhealthy');
   });
 
   it('shows orange on backpressure', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ json: () => Promise.resolve({ status: 'backpressure', reasons: ['busy'] }) }));
     render(<HealthBadge />);
-    await screen.findAllByText('Health');
+    await screen.findByLabelText('health-backpressure');
   });
 });

--- a/frontend/src/components/HealthBadge.tsx
+++ b/frontend/src/components/HealthBadge.tsx
@@ -1,5 +1,11 @@
 import { useEffect, useState } from 'react';
-import { Badge, Tooltip } from 'antd';
+import { Badge, Tooltip, Space } from 'antd';
+import {
+  CheckCircleOutlined,
+  CloseCircleOutlined,
+  ExclamationCircleOutlined,
+  LoadingOutlined,
+} from '@ant-design/icons';
 
 type HealthResponse = { status?: string; reasons?: string[] };
 
@@ -12,9 +18,25 @@ const colorMap: Record<Status, string> = {
   backpressure: 'orange',
 };
 
+function statusIcon(status: Status) {
+  const props = { 'aria-label': `health-${status}` } as const;
+  switch (status) {
+    case 'ok':
+      return <CheckCircleOutlined {...props} style={{ color: 'green' }} />;
+    case 'unhealthy':
+      return <CloseCircleOutlined {...props} style={{ color: 'red' }} />;
+    case 'backpressure':
+      return <ExclamationCircleOutlined {...props} style={{ color: 'orange' }} />;
+    default:
+      return <LoadingOutlined {...props} />;
+  }
+}
+
 export default function HealthBadge() {
   const [health, setHealth] = useState<HealthResponse | null>(null);
-  const status: Status = health ? (health.status as Status) : 'loading';
+  const status: Status = health
+    ? ((health.status === 'healthy' ? 'ok' : (health.status as Status)))
+    : 'loading';
 
   useEffect(() => {
     let cancelled = false;
@@ -39,7 +61,15 @@ export default function HealthBadge() {
 
   return (
     <Tooltip title={health?.reasons?.join(', ') || ''}>
-      <Badge color={colorMap[status]} text="Health" />
+      <Badge
+        color={colorMap[status]}
+        text={
+          <Space align="center" size="small">
+            {statusIcon(status)}
+            Health
+          </Space>
+        }
+      />
     </Tooltip>
   );
 }

--- a/frontend/src/pages/HealthPage.tsx
+++ b/frontend/src/pages/HealthPage.tsx
@@ -7,7 +7,9 @@ type HealthResponse = { status?: string; reasons?: string[] };
 type Status = 'ok' | 'unhealthy' | 'backpressure' | 'loading';
 
 function statusIcon(status: string | undefined, prefix: string) {
-  const s: Status = status ? (status as Status) : 'loading';
+  const s: Status = status
+    ? ((status === 'healthy' ? 'ok' : (status as Status)))
+    : 'loading';
   const props = { 'aria-label': `${prefix}-${s}` } as const;
   switch (s) {
     case 'ok':
@@ -29,7 +31,7 @@ function StatusCard({ label, data, prefix }: { label: string; data: HealthRespon
         <Space align="center">
           {statusIcon(data?.status, prefix)}
           <Typography.Text strong>{label}:</Typography.Text>
-          <Typography.Text>{data?.status ?? 'unknown'}</Typography.Text>
+          <Typography.Text>{data?.status === 'healthy' ? 'ok' : data?.status ?? 'unknown'}</Typography.Text>
         </Space>
         {reasons.length > 0 && (
           <List size="small" dataSource={reasons} renderItem={(item) => <List.Item>{item}</List.Item>} />

--- a/frontend/tests/routing.e2e.spec.ts
+++ b/frontend/tests/routing.e2e.spec.ts
@@ -24,9 +24,7 @@ test('health badge shows state', async ({ page }) => {
     localStorage.setItem('apiKey', 'dev-secret-key-change-me')
   );
   await page.reload();
-  await expect(
-    page.getByRole('banner').locator('.ant-badge-status-dot'),
-  ).toHaveCSS('background-color', 'rgb(245, 34, 45)');
+  await expect(page.getByLabel('health-unhealthy')).toBeVisible();
   const badge = page.getByRole('banner').locator('.ant-badge-status');
   await badge.hover();
   await expect(page.getByRole('tooltip')).toHaveText('disk_full');

--- a/tests/DocflowAi.Net.Api.Tests/HealthLiveTests.cs
+++ b/tests/DocflowAi.Net.Api.Tests/HealthLiveTests.cs
@@ -1,0 +1,25 @@
+using System.Net;
+using DocflowAi.Net.Api.Tests.Fixtures;
+using System.Net.Http.Json;
+using FluentAssertions;
+
+namespace DocflowAi.Net.Api.Tests;
+
+public class HealthLiveTests : IClassFixture<TempDirFixture>
+{
+    private readonly TempDirFixture _fixture;
+    public HealthLiveTests(TempDirFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task Live_ReturnsOk()
+    {
+        using var factory = new TestWebAppFactory(_fixture.RootPath);
+        var client = factory.CreateClient();
+        var resp = await client.GetAsync("/health/live");
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = await resp.Content.ReadFromJsonAsync<LiveResp>();
+        json!.status.Should().Be("ok");
+    }
+
+    private record LiveResp(string status);
+}


### PR DESCRIPTION
## Summary
- show icons for health states and map "healthy" to "ok"
- return JSON from live health endpoint
- cover live health check with test

## Testing
- `rg -n -i 'pytest|:8000|sidecar|MarkitdownException|MARKITDOWN_URL|PY_MARKITDOWN_ENABLED'`
- `dotnet build -c Release`
- `dotnet test -c Release`
- `npm test -- --run`
- `npm run build`
- `npx playwright install`
- `npx playwright install-deps`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_689f0cee7620832588c88f516fef4ac7