### PR TITLE
docs: document database providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,21 @@ End-to-end pipeline for extracting information from documents with **LLMs** and 
 1. Integrated **Hangfire** (MemoryStorage), **SQLite** via **Entity Framework Core** and **Rate Limiting** with paged `GET /api/v1/jobs`.
 2. Added `POST /api/v1/jobs` for submission (base64/multipart), `GET /api/v1/jobs/{id}` and `DELETE /api/v1/jobs/{id}` with state managed exclusively by the database and artifacts stored on disk.
 
+### Database Providers
+
+The job queue persistence layer uses Entity Framework Core and supports the following providers:
+
+- **InMemory** — convenient for tests and temporary runs.
+- **SQLite** — default lightweight storage.
+
+Switch the provider through `JobQueue:Database` in `appsettings.*.json`.
+
+#### Adding a new provider
+
+1. Add the appropriate EF Core package for the target database.
+2. Extend the `switch` statement in `Program.cs` to call `Use<Provider>()`.
+3. Configure `JobQueue:Database:Provider` and `ConnectionString` with the new settings.
+
 ## High-level Architecture
 
 ```


### PR DESCRIPTION
## Summary
- document supported database providers and how to add new ones

## Testing
- `rg -n -i 'pytest|:8000|sidecar|MarkitdownException|MARKITDOWN_URL|PY_MARKITDOWN_ENABLED' --glob '!AGENTS.md'`
- `git submodule update --init --recursive`
- `dotnet build -c Release`
- `dotnet test -c Release`


------
https://chatgpt.com/codex/tasks/task_e_689f567ed6f88325bfa9dc4f1a49adb5