### PR TITLE
Show loader while refreshing health status

### DIFF
--- a/frontend/src/pages/HealthPage.test.tsx
+++ b/frontend/src/pages/HealthPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { afterEach, describe, it, vi } from 'vitest';
 import HealthPage from './HealthPage';
 
@@ -19,5 +19,20 @@ describe('HealthPage', () => {
     render(<HealthPage />);
     await screen.findByLabelText('ready-ok');
     await screen.findByLabelText('live-unhealthy');
+  });
+
+  it('shows loader while retrying', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ json: () => Promise.resolve({ status: 'ok', reasons: [] }) })
+      .mockResolvedValueOnce({ json: () => Promise.resolve({ status: 'ok', reasons: [] }) })
+      .mockResolvedValueOnce({ json: () => Promise.resolve({ status: 'ok', reasons: [] }) })
+      .mockImplementationOnce(() => new Promise(() => {}));
+    vi.stubGlobal('fetch', fetchMock);
+    render(<HealthPage />);
+    await screen.findByLabelText('ready-ok');
+    const [retry] = screen.getAllByRole('button', { name: /retry/i });
+    fireEvent.click(retry);
+    screen.getByLabelText('ready-loading');
   });
 });

--- a/frontend/src/pages/HealthPage.tsx
+++ b/frontend/src/pages/HealthPage.tsx
@@ -44,8 +44,12 @@ function StatusCard({ label, data, prefix }: { label: string; data: HealthRespon
 export default function HealthPage() {
   const [ready, setReady] = useState<HealthResponse | null>(null);
   const [live, setLive] = useState<HealthResponse | null>(null);
+  const [loading, setLoading] = useState(false);
 
   const load = async () => {
+    setLoading(true);
+    setReady(null);
+    setLive(null);
     const api = (import.meta.env.VITE_API_BASE_URL || '').replace(/\/$/, '');
     const base = api.replace(/\/api\/v1$/, '');
     try {
@@ -60,6 +64,7 @@ export default function HealthPage() {
     } catch {
       setLive({ reasons: ['fetch_failed'] });
     }
+    setLoading(false);
   };
 
   useEffect(() => {
@@ -70,7 +75,9 @@ export default function HealthPage() {
     <Space direction="vertical" style={{ width: '100%' }} size="large">
       <Typography.Title level={2}>Health</Typography.Title>
       <HealthBadge />
-      <Button onClick={load}>Retry</Button>
+      <Button onClick={load} loading={loading}>
+        Retry
+      </Button>
       <Row gutter={[16, 16]}>
         <Col xs={24} md={12}>
           <StatusCard label="Ready" data={ready} prefix="ready" />


### PR DESCRIPTION
## Summary
- display a loading state when retrying the health checks
- cover retry loader with a unit test

## Testing
- `rg -n -i 'pytest|:8000|sidecar|MarkitdownException|MARKITDOWN_URL|PY_MARKITDOWN_ENABLED' --glob '!AGENTS.md'`
- `dotnet build -c Release`
- `dotnet test -c Release --no-build`
- `npm test -- --run`
- `npm run build`
- `npx playwright install`
- `npx playwright install-deps`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_689f78fbbdfc83258a9c7691dc31e096