### PR TITLE
feat(frontend): label model switch inputs and unify widths

### DIFF
--- a/frontend/src/components/ModelSwitchSelect.test.tsx
+++ b/frontend/src/components/ModelSwitchSelect.test.tsx
@@ -24,4 +24,12 @@ describe('ModelSwitchSelect', () => {
     await new Promise((r) => setTimeout(r, 0));
     expect(reload).toHaveBeenCalled();
   });
+
+  it('renders labels for model and context size', () => {
+    render(
+      <ModelSwitchSelect models={['a.gguf']} onSwitch={vi.fn()} />,
+    );
+    expect(screen.getByLabelText('Model file')).toBeInTheDocument();
+    expect(screen.getByLabelText('Context size')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/ModelSwitchSelect.tsx
+++ b/frontend/src/components/ModelSwitchSelect.tsx
@@ -34,38 +34,48 @@ export default function ModelSwitchSelect({
     setRefreshing(false);
   };
 
+  const inputWidth = screens.xs ? '100%' : 200;
+
   return (
     <Space
       direction={screens.xs ? 'vertical' : 'horizontal'}
       style={{ width: '100%' }}
       align={screens.xs ? 'start' : 'center'}
     >
-      <Space.Compact style={{ width: screens.xs ? '100%' : 200 }}>
-        <Select
+      <div style={{ width: inputWidth }}>
+        <label htmlFor="model-select">Model file</label>
+        <Space.Compact style={{ width: '100%' }}>
+          <Select
+            id="model-select"
+            style={{ width: '100%' }}
+            placeholder="Select model"
+            value={file}
+            onChange={setFile}
+            options={models.map((m) => ({ value: m, label: m }))}
+            disabled={disabled}
+            data-testid="model-select"
+          />
+          <Button
+            icon={<ReloadOutlined />}
+            onClick={reload}
+            disabled={disabled}
+            loading={refreshing}
+            data-testid="reload-models"
+          />
+        </Space.Compact>
+      </div>
+      <div style={{ width: inputWidth }}>
+        <label htmlFor="context-size">Context size</label>
+        <InputNumber
+          id="context-size"
+          min={1024}
+          max={16384}
+          value={ctx}
+          onChange={(v) => setCtx(v ?? 0)}
+          disabled={disabled}
           style={{ width: '100%' }}
-          placeholder="Select model"
-          value={file}
-          onChange={setFile}
-          options={models.map((m) => ({ value: m, label: m }))}
-          disabled={disabled}
-          data-testid="model-select"
         />
-        <Button
-          icon={<ReloadOutlined />}
-          onClick={reload}
-          disabled={disabled}
-          loading={refreshing}
-          data-testid="reload-models"
-        />
-      </Space.Compact>
-      <InputNumber
-        min={1024}
-        max={16384}
-        value={ctx}
-        onChange={(v) => setCtx(v ?? 0)}
-        disabled={disabled}
-        style={{ width: screens.xs ? '100%' : undefined }}
-      />
+      </div>
       <Button
         onClick={handle}
         disabled={!file || disabled}


### PR DESCRIPTION
## Summary
- add external labels to model selection and context size inputs
- ensure text box and select share equal width
- cover labels with unit tests

## Testing
- `rg -n -i 'pytest|:8000|sidecar|MarkitdownException|MARKITDOWN_URL|PY_MARKITDOWN_ENABLED' -g '!AGENTS.md'`
- `dotnet build -c Release`
- `dotnet test -c Release`
- `npm test -- --run`
- `npm run build`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_689faca1c6cc83258499d3449e1fa1af