### PR TITLE
chore: remove hangfire button from jobs list

### DIFF
--- a/frontend/src/pages/JobsList.tsx
+++ b/frontend/src/pages/JobsList.tsx
@@ -6,7 +6,6 @@ import { JobsService, type JobDetailResponse, ApiError } from '../generated';
 import JobStatusTag from '../components/JobStatusTag';
 import { Link } from 'react-router-dom';
 import dayjs from 'dayjs';
-import { openHangfire } from '../hangfire';
 import type { PaginationProps } from 'antd';
 
 const terminal = ['Succeeded', 'Failed', 'Cancelled'];
@@ -170,7 +169,6 @@ export default function JobsList() {
         <Link to="/jobs/new">
           <Button aria-label="New Job" icon={<FileAddOutlined />} />
         </Link>
-        <Button onClick={openHangfire}>Open Hangfire</Button>
       </div>
       {retry !== null && <Alert banner message={`Queue full. Retry in ${retry}s`} />}
       {isMobile ? (

--- a/frontend/tests/jobs.e2e.spec.ts
+++ b/frontend/tests/jobs.e2e.spec.ts
@@ -100,3 +100,8 @@ test('new job button navigates to form', async ({ page }) => {
   await expect(page).toHaveURL(/\/jobs\/new$/);
 });
 
+test('does not show hangfire button', async ({ page }) => {
+  await page.goto('/jobs');
+  await expect(page.getByRole('button', { name: 'Open Hangfire' })).toHaveCount(0);
+});
+


### PR DESCRIPTION
## Summary
- remove redundant Hangfire button from job list
- add E2E coverage for absence of Hangfire button

## Testing
- `rg -n -i 'pytest|:8000|sidecar|MarkitdownException|MARKITDOWN_URL|PY_MARKITDOWN_ENABLED' -g '!AGENTS.md'`
- `dotnet build -c Release`
- `dotnet test -c Release`
- `npm test -- --run`
- `npm run build`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_689fadfb16508325b69c949577e79130