### PR TITLE
Add configurable default job seeding

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ End-to-end pipeline for extracting information from documents with **LLMs** and 
 1. Integrated **Hangfire** (MemoryStorage), **SQLite** via **Entity Framework Core** and **Rate Limiting** with paged `GET /api/v1/jobs`.
 2. Added `POST /api/v1/jobs` for submission (base64/multipart), `GET /api/v1/jobs/{id}` and `DELETE /api/v1/jobs/{id}` with state managed exclusively by the database and artifacts stored on disk.
 
+### Default Records
+
+At startup the API can optionally seed two sample jobs using files from the `dataset` directory. The flag `JobQueue:SeedDefaults` in `appsettings.json` controls this behavior and defaults to `true`.
+
 ### Database Providers
 
 The job queue persistence layer uses Entity Framework Core and supports the following providers:

--- a/src/DocflowAi.Net.Api/Options/JobQueueOptions.cs
+++ b/src/DocflowAi.Net.Api/Options/JobQueueOptions.cs
@@ -1,19 +1,20 @@
 namespace DocflowAi.Net.Api.Options;
 
-public class JobQueueOptions
-{
-    public const string SectionName = "JobQueue";
-    public string DataRoot { get; set; } = "./data/jobs";
-    public DatabaseOptions Database { get; set; } = new();
-    public QueueOptions Queue { get; set; } = new();
-    public RateLimitOptions RateLimit { get; set; } = new();
-    public ConcurrencyOptions Concurrency { get; set; } = new();
-    public TimeoutOptions Timeouts { get; set; } = new();
-    public UploadOptions UploadLimits { get; set; } = new();
-    public ImmediateOptions Immediate { get; set; } = new();
-    public CleanupOptions Cleanup { get; set; } = new();
-    public int JobTTLDays { get; set; } = 14;
-    public bool EnableDashboard { get; set; } = true;
+    public class JobQueueOptions
+    {
+        public const string SectionName = "JobQueue";
+        public string DataRoot { get; set; } = "./data/jobs";
+        public DatabaseOptions Database { get; set; } = new();
+        public QueueOptions Queue { get; set; } = new();
+        public RateLimitOptions RateLimit { get; set; } = new();
+        public ConcurrencyOptions Concurrency { get; set; } = new();
+        public TimeoutOptions Timeouts { get; set; } = new();
+        public UploadOptions UploadLimits { get; set; } = new();
+        public ImmediateOptions Immediate { get; set; } = new();
+        public CleanupOptions Cleanup { get; set; } = new();
+        public int JobTTLDays { get; set; } = 14;
+        public bool EnableDashboard { get; set; } = true;
+        public bool SeedDefaults { get; set; } = true;
 
     public class DatabaseOptions
     {

--- a/src/DocflowAi.Net.Api/Program.cs
+++ b/src/DocflowAi.Net.Api/Program.cs
@@ -32,9 +32,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using Serilog;
 using DocflowAi.Net.Api.Security;
-using Microsoft.Data.Sqlite;
 using System.IO;
-using System.Linq;
 using System.Collections.Generic;
 using Hangfire.Dashboard;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
@@ -192,22 +190,7 @@ builder.Services.AddHealthChecks()
     .AddCheck<JobQueueReadyHealthCheck>("jobqueue", tags: new[] { "ready" });
 
 var app = builder.Build();
-
-using (var scope = app.Services.CreateScope())
-{
-    var cfg = scope.ServiceProvider.GetRequiredService<IOptions<JobQueueOptions>>().Value;
-    Directory.CreateDirectory(cfg.DataRoot);
-    if (cfg.Database.Provider.Equals("sqlite", StringComparison.OrdinalIgnoreCase))
-    {
-        var csb = new SqliteConnectionStringBuilder(cfg.Database.ConnectionString);
-        var dbPath = csb.DataSource;
-        var dir = Path.GetDirectoryName(dbPath);
-        if (!string.IsNullOrEmpty(dir))
-            Directory.CreateDirectory(dir);
-    }
-    var db = scope.ServiceProvider.GetRequiredService<JobDbContext>();
-    db.Database.EnsureCreated();
-}
+DefaultJobSeeder.Build(app);
 
 app.UseSerilogRequestLogging(opts =>
 {

--- a/src/DocflowAi.Net.Api/appsettings.json
+++ b/src/DocflowAi.Net.Api/appsettings.json
@@ -78,6 +78,7 @@
     "UploadLimits": { "MaxRequestBodyMB": 20 },
     "JobTTLDays": 14,
     "EnableDashboard": true,
+    "SeedDefaults": true,
     "Immediate": { "Enabled": true, "MaxParallel": 1, "TimeoutSeconds": 50, "FallbackToQueue": true },
     "Cleanup": { "Enabled": true, "DailyHour": 3, "DailyMinute": 15 }
   },

--- a/tests/DocflowAi.Net.Api.Tests/ImmediateCapacityAndFallbackTests.cs
+++ b/tests/DocflowAi.Net.Api.Tests/ImmediateCapacityAndFallbackTests.cs
@@ -23,7 +23,7 @@ public class ImmediateCapacityAndFallbackTests : IClassFixture<TempDirFixture>
         var client = factory.CreateClient();
         var payload = new { fileBase64 = Convert.ToBase64String(new byte[]{1}), fileName = "a.pdf" };
         var first = client.PostAsJsonAsync("/api/v1/jobs?mode=immediate", payload); // running
-        await Task.Delay(100); // ensure started
+        await Task.Delay(200); // ensure started
         var secondPayload = new { fileBase64 = Convert.ToBase64String(new byte[]{2}), fileName = "b.pdf" };
         var second = await client.PostAsJsonAsync("/api/v1/jobs?mode=immediate", secondPayload);
         second.StatusCode.Should().Be(System.Net.HttpStatusCode.TooManyRequests);
@@ -40,7 +40,7 @@ public class ImmediateCapacityAndFallbackTests : IClassFixture<TempDirFixture>
         var client = factory.CreateClient();
         var payload = new { fileBase64 = Convert.ToBase64String(new byte[]{1}), fileName = "a.pdf" };
         var first = client.PostAsJsonAsync("/api/v1/jobs?mode=immediate", payload);
-        await Task.Delay(100);
+        await Task.Delay(200);
         var secondPayload = new { fileBase64 = Convert.ToBase64String(new byte[]{2}), fileName = "b.pdf" };
         var second = await client.PostAsJsonAsync("/api/v1/jobs?mode=immediate", secondPayload);
         second.StatusCode.Should().Be(System.Net.HttpStatusCode.Accepted);

--- a/tests/DocflowAi.Net.Api.Tests/TestWebAppFactory.cs
+++ b/tests/DocflowAi.Net.Api.Tests/TestWebAppFactory.cs
@@ -64,6 +64,7 @@ public class TestWebAppFactory : WebApplicationFactory<Program>
                 ["JobQueue:Queue:MaxQueueLength"] = _maxQueueLength.ToString(),
                 ["JobQueue:Concurrency:HangfireWorkerCount"] = _workerCount.ToString(),
                 ["JobQueue:UploadLimits:MaxRequestBodyMB"] = _uploadLimitMb.ToString(),
+                ["JobQueue:SeedDefaults"] = "false",
                 ["Serilog:Using:0"] = "Serilog.Sinks.TestCorrelator",
                 ["Serilog:WriteTo:0:Name"] = "TestCorrelator"
             };

--- a/tests/DocflowAi.Net.Api.Tests/TestWebAppFactory_Immediate.cs
+++ b/tests/DocflowAi.Net.Api.Tests/TestWebAppFactory_Immediate.cs
@@ -54,7 +54,8 @@ public class TestWebAppFactory_Immediate : WebApplicationFactory<Program>
                 ["JobQueue:Queue:MaxQueueLength"] = _maxQueueLength.ToString(),
                 ["JobQueue:Concurrency:HangfireWorkerCount"] = "1",
                 ["Serilog:WriteTo:0:Name"] = "TestCorrelator",
-                ["JobQueue:EnableDashboard"] = "false"
+                ["JobQueue:EnableDashboard"] = "false",
+                ["JobQueue:SeedDefaults"] = "false"
             };
             config.AddInMemoryCollection(dict);
             Log.Logger = new LoggerConfiguration().MinimumLevel.Debug().Enrich.FromLogContext().WriteTo.TestCorrelator().CreateLogger();

--- a/tests/DocflowAi.Net.Api.Tests/TestWebAppFactory_Step3A.cs
+++ b/tests/DocflowAi.Net.Api.Tests/TestWebAppFactory_Step3A.cs
@@ -43,7 +43,8 @@ public class TestWebAppFactory_Step3A : WebApplicationFactory<Program>
                 ["JobQueue:Timeouts:JobTimeoutSeconds"] = _timeoutSeconds.ToString(),
                 ["JobQueue:Concurrency:HangfireWorkerCount"] = "1",
                 ["Serilog:WriteTo:0:Name"] = "TestCorrelator",
-                ["JobQueue:EnableDashboard"] = "false"
+                ["JobQueue:EnableDashboard"] = "false",
+                ["JobQueue:SeedDefaults"] = "false"
             };
             config.AddInMemoryCollection(dict);
             Log.Logger = new LoggerConfiguration()

--- a/tests/DocflowAi.Net.Api.Tests/TestWebAppFactory_Step3B.cs
+++ b/tests/DocflowAi.Net.Api.Tests/TestWebAppFactory_Step3B.cs
@@ -47,7 +47,8 @@ public class TestWebAppFactory_Step3B : WebApplicationFactory<Program>
                 ["JobQueue:Timeouts:JobTimeoutSeconds"] = "3",
                 ["Serilog:Using:0"] = "Serilog.Sinks.TestCorrelator",
                 ["Serilog:WriteTo:0:Name"] = "TestCorrelator",
-                ["JobQueue:EnableDashboard"] = "false"
+                ["JobQueue:EnableDashboard"] = "false",
+                ["JobQueue:SeedDefaults"] = "false"
             };
             config.AddInMemoryCollection(dict);
         });


### PR DESCRIPTION
## Summary
- seed two sample jobs on startup using files from `dataset`
- make seeding configurable via `JobQueue:SeedDefaults`
- document default seeding flag
- move startup seeding to `DefaultJobSeeder` and call from `Program`
- stabilize immediate-mode tests with longer startup wait

## Testing
- `rg -n -i 'pytest|:8000|sidecar|MarkitdownException|MARKITDOWN_URL|PY_MARKITDOWN_ENABLED' -g '!*AGENTS.md'`
- `dotnet build -c Release`
- `dotnet test -c Release`


------
https://chatgpt.com/codex/tasks/task_e_689fb5e68dbc8325ace5647ba3ca6a88