### PR TITLE
fix: optimize bundle splitting under 500kb

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,12 +1,12 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, lazy, Suspense } from 'react';
 import { Routes, Route, Navigate } from 'react-router-dom';
-import Login from './pages/Login';
-import Shell from './Shell';
-import JobsList from './pages/JobsList';
-import JobNew from './pages/JobNew';
-import JobDetail from './pages/JobDetail';
-import HealthPage from './pages/HealthPage';
-import ModelManagerPage from './pages/ModelManagerPage';
+const Login = lazy(() => import('./pages/Login'));
+const Shell = lazy(() => import('./Shell'));
+const JobsList = lazy(() => import('./pages/JobsList'));
+const JobNew = lazy(() => import('./pages/JobNew'));
+const JobDetail = lazy(() => import('./pages/JobDetail'));
+const HealthPage = lazy(() => import('./pages/HealthPage'));
+const ModelManagerPage = lazy(() => import('./pages/ModelManagerPage'));
 import { OpenAPI } from './generated';
 
 function App() {
@@ -19,20 +19,26 @@ function App() {
     localStorage.setItem('apiKey', key);
   };
   if (!apiKey) {
-    return <Login onLogin={handleLogin} />;
+    return (
+      <Suspense fallback={<div>Loading...</div>}>
+        <Login onLogin={handleLogin} />
+      </Suspense>
+    );
   }
   return (
-    <Routes>
-      <Route path="/" element={<Shell />}>
-        <Route index element={<Navigate to="/jobs" />} />
-        <Route path="jobs" element={<JobsList />} />
-        <Route path="jobs/new" element={<JobNew />} />
-        <Route path="jobs/:id" element={<JobDetail />} />
-        <Route path="health" element={<HealthPage />} />
-        <Route path="model" element={<ModelManagerPage />} />
-        <Route path="*" element={<Navigate to="/jobs" />} />
-      </Route>
-    </Routes>
+    <Suspense fallback={<div>Loading...</div>}>
+      <Routes>
+        <Route path="/" element={<Shell />}>
+          <Route index element={<Navigate to="/jobs" />} />
+          <Route path="jobs" element={<JobsList />} />
+          <Route path="jobs/new" element={<JobNew />} />
+          <Route path="jobs/:id" element={<JobDetail />} />
+          <Route path="health" element={<HealthPage />} />
+          <Route path="model" element={<ModelManagerPage />} />
+          <Route path="*" element={<Navigate to="/jobs" />} />
+        </Route>
+      </Routes>
+    </Suspense>
   );
 }
 

--- a/frontend/src/Shell.tsx
+++ b/frontend/src/Shell.tsx
@@ -1,12 +1,10 @@
 import { Layout, Menu } from 'antd';
 import { useNavigate, Outlet, useLocation } from 'react-router-dom';
-import {
-  AppstoreOutlined,
-  FileAddOutlined,
-  HeartOutlined,
-  LinkOutlined,
-  ExperimentOutlined,
-} from '@ant-design/icons';
+import AppstoreOutlined from '@ant-design/icons/AppstoreOutlined';
+import FileAddOutlined from '@ant-design/icons/FileAddOutlined';
+import HeartOutlined from '@ant-design/icons/HeartOutlined';
+import LinkOutlined from '@ant-design/icons/LinkOutlined';
+import ExperimentOutlined from '@ant-design/icons/ExperimentOutlined';
 import HealthBadge from './components/HealthBadge';
 import { openHangfire } from './hangfire';
 

--- a/frontend/src/components/FieldsEditor.tsx
+++ b/frontend/src/components/FieldsEditor.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Button, Input, Select, Space } from 'antd';
-import { MinusCircleOutlined, PlusOutlined } from '@ant-design/icons';
+import MinusCircleOutlined from '@ant-design/icons/MinusCircleOutlined';
+import PlusOutlined from '@ant-design/icons/PlusOutlined';
 
 export interface FieldItem {
   name: string;

--- a/frontend/src/components/HealthBadge.tsx
+++ b/frontend/src/components/HealthBadge.tsx
@@ -1,11 +1,9 @@
 import { useEffect, useState } from 'react';
 import { Badge, Tooltip, Space } from 'antd';
-import {
-  CheckCircleOutlined,
-  CloseCircleOutlined,
-  ExclamationCircleOutlined,
-  LoadingOutlined,
-} from '@ant-design/icons';
+import CheckCircleOutlined from '@ant-design/icons/CheckCircleOutlined';
+import CloseCircleOutlined from '@ant-design/icons/CloseCircleOutlined';
+import ExclamationCircleOutlined from '@ant-design/icons/ExclamationCircleOutlined';
+import LoadingOutlined from '@ant-design/icons/LoadingOutlined';
 
 type HealthResponse = { status?: string; reasons?: string[] };
 

--- a/frontend/src/components/ModelSwitchSelect.tsx
+++ b/frontend/src/components/ModelSwitchSelect.tsx
@@ -1,5 +1,5 @@
 import { Select, InputNumber, Button, Space, Grid } from 'antd';
-import { ReloadOutlined } from '@ant-design/icons';
+import ReloadOutlined from '@ant-design/icons/ReloadOutlined';
 import { useState } from 'react';
 
 type Props = {

--- a/frontend/src/pages/HealthPage.tsx
+++ b/frontend/src/pages/HealthPage.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useState } from 'react';
 import { Button, Card, Col, Row, Space, Typography, List } from 'antd';
-import { CheckCircleOutlined, CloseCircleOutlined, ExclamationCircleOutlined, LoadingOutlined } from '@ant-design/icons';
+import CheckCircleOutlined from '@ant-design/icons/CheckCircleOutlined';
+import CloseCircleOutlined from '@ant-design/icons/CloseCircleOutlined';
+import ExclamationCircleOutlined from '@ant-design/icons/ExclamationCircleOutlined';
+import LoadingOutlined from '@ant-design/icons/LoadingOutlined';
 import HealthBadge from '../components/HealthBadge';
 
 type HealthResponse = { status?: string; reasons?: string[] };

--- a/frontend/src/pages/JobDetail.tsx
+++ b/frontend/src/pages/JobDetail.tsx
@@ -3,12 +3,10 @@ import { useParams } from 'react-router-dom';
 import { JobsService, type JobDetailResponse, OpenAPI, ApiError } from '../generated';
 import { request as __request } from '../generated/core/request';
 import { Descriptions, Progress, Button, message, Space, Modal, Tabs, Table } from 'antd';
-import {
-  ReloadOutlined,
-  StopOutlined,
-  FileSearchOutlined,
-  DownloadOutlined,
-} from '@ant-design/icons';
+import ReloadOutlined from '@ant-design/icons/ReloadOutlined';
+import StopOutlined from '@ant-design/icons/StopOutlined';
+import FileSearchOutlined from '@ant-design/icons/FileSearchOutlined';
+import DownloadOutlined from '@ant-design/icons/DownloadOutlined';
 import JobStatusTag from '../components/JobStatusTag';
 import MarkdownPreview from '@uiw/react-markdown-preview';
 import JsonView from '@uiw/react-json-view';

--- a/frontend/src/pages/JobNew.tsx
+++ b/frontend/src/pages/JobNew.tsx
@@ -16,7 +16,7 @@ import {
 import MDEditor from '@uiw/react-md-editor';
 import '@uiw/react-md-editor/markdown-editor.css';
 import '@uiw/react-markdown-preview/markdown.css';
-import { InboxOutlined } from '@ant-design/icons';
+import InboxOutlined from '@ant-design/icons/InboxOutlined';
 import FieldsEditor, {
   fieldsToJson,
   jsonToFields,

--- a/frontend/src/pages/JobsList.tsx
+++ b/frontend/src/pages/JobsList.tsx
@@ -1,12 +1,10 @@
 import { useEffect, useState } from 'react';
 import { Table, Space, Button, Progress, Badge, Alert, message, List, Grid } from 'antd';
-import {
-  FileAddOutlined,
-  EyeOutlined,
-  StopOutlined,
-  FileTextOutlined,
-  FileExclamationOutlined,
-} from '@ant-design/icons';
+import FileAddOutlined from '@ant-design/icons/FileAddOutlined';
+import EyeOutlined from '@ant-design/icons/EyeOutlined';
+import StopOutlined from '@ant-design/icons/StopOutlined';
+import FileTextOutlined from '@ant-design/icons/FileTextOutlined';
+import FileExclamationOutlined from '@ant-design/icons/FileExclamationOutlined';
 import type { ColumnsType, TablePaginationConfig } from 'antd/es/table';
 import { JobsService, type JobDetailResponse, ApiError } from '../generated';
 import JobStatusTag from '../components/JobStatusTag';

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,6 +4,33 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  build: {
+    chunkSizeWarningLimit: 500,
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (id.includes('node_modules')) {
+            const parts = id.split('node_modules/')[1].split('/');
+            const pkg = parts[0].startsWith('@') ? `${parts[0]}/${parts[1]}` : parts[0];
+            if (['react', 'react-dom', 'react-router-dom'].includes(pkg)) {
+              return 'react';
+            }
+            if (pkg === 'refractor') {
+              const langIndex = parts.indexOf('lang');
+              if (langIndex > -1 && parts.length > langIndex + 1) {
+                return `refractor-${parts[langIndex + 1]}`;
+              }
+              return 'refractor';
+            }
+            if (pkg === 'antd' || pkg.startsWith('@ant-design')) {
+              return undefined;
+            }
+            return pkg;
+          }
+        },
+      },
+    },
+  },
   // @ts-ignore - Vitest configuration
   test: {
     environment: 'jsdom',


### PR DESCRIPTION
## Summary
- revert Vite chunk warning limit to 500kB and split vendor modules per package
- import Ant Design icons individually to avoid bundling the full set

## Testing
- `rg -n -i --glob '!*AGENTS.md' 'pytest|:8000|sidecar|MarkitdownException|MARKITDOWN_URL|PY_MARKITDOWN_ENABLED'`
- `dotnet build -c Release`
- `dotnet test -c Release`
- `npx --yes playwright install`
- `npx --yes playwright install-deps`
- `npm test -- --run`
- `npm run build`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_68a098b398608325a8856384fb4b63bc