### PR TITLE
Add populated job seed output

### DIFF
--- a/dataset/test-png-boxsolver-pointerstrategy/result.json
+++ b/dataset/test-png-boxsolver-pointerstrategy/result.json
@@ -120,5 +120,165 @@
       "Start": null,
       "End": null
     }
+  },
+  {
+    "FieldName": "prezzo",
+    "Value": "€ 10,00",
+    "Confidence": 1,
+    "Spans": [
+      {
+        "Page": 0,
+        "WordIndices": [
+          17,
+          18
+        ],
+        "BBox": {
+          "X": 0.7026624,
+          "Y": 0.23254825,
+          "W": 0.05604124,
+          "H": 0.008575946
+        },
+        "Text": "€ 10,00",
+        "Score": 1,
+        "Label": null
+      }
+    ],
+    "Pointer": {
+      "Mode": 0,
+      "WordIds": [
+        "W0_17",
+        "W0_18"
+      ],
+      "Start": null,
+      "End": null
+    }
+  },
+  {
+    "FieldName": "prezzo",
+    "Value": "€ 15,00",
+    "Confidence": 1,
+    "Spans": [
+      {
+        "Page": 0,
+        "WordIndices": [
+          24,
+          25
+        ],
+        "BBox": {
+          "X": 0.7026624,
+          "Y": 0.25392872,
+          "W": 0.05604124,
+          "H": 0.008575946
+        },
+        "Text": "€ 15,00",
+        "Score": 1,
+        "Label": null
+      }
+    ],
+    "Pointer": {
+      "Mode": 0,
+      "WordIds": [
+        "W0_24",
+        "W0_25"
+      ],
+      "Start": null,
+      "End": null
+    }
+  },
+  {
+    "FieldName": "descrizione",
+    "Value": "Prodotto A",
+    "Confidence": 1,
+    "Spans": [
+      {
+        "Page": 0,
+        "WordIndices": [
+          14,
+          15
+        ],
+        "BBox": {
+          "X": 0.07330689,
+          "Y": 0.2324176,
+          "W": 0.079375,
+          "H": 0.0087065995
+        },
+        "Text": "Prodotto A",
+        "Score": 1,
+        "Label": null
+      }
+    ],
+    "Pointer": {
+      "Mode": 0,
+      "WordIds": [
+        "W0_14",
+        "W0_15"
+      ],
+      "Start": null,
+      "End": null
+    }
+  },
+  {
+    "FieldName": "descrizione",
+    "Value": "Prodotto B",
+    "Confidence": 1,
+    "Spans": [
+      {
+        "Page": 0,
+        "WordIndices": [
+          21,
+          22
+        ],
+        "BBox": {
+          "X": 0.07330689,
+          "Y": 0.25379807,
+          "W": 0.079375,
+          "H": 0.0087065995
+        },
+        "Text": "Prodotto B",
+        "Score": 1,
+        "Label": null
+      }
+    ],
+    "Pointer": {
+      "Mode": 0,
+      "WordIds": [
+        "W0_21",
+        "W0_22"
+      ],
+      "Start": null,
+      "End": null
+    }
+  },
+  {
+    "FieldName": "totale",
+    "Value": "€ 35,00",
+    "Confidence": 1,
+    "Spans": [
+      {
+        "Page": 0,
+        "WordIndices": [
+          29,
+          30
+        ],
+        "BBox": {
+          "X": 0.87065184,
+          "Y": 0.2753092,
+          "W": 0.05604124,
+          "H": 0.008575946
+        },
+        "Text": "€ 35,00",
+        "Score": 1,
+        "Label": null
+      }
+    ],
+    "Pointer": {
+      "Mode": 0,
+      "WordIds": [
+        "W0_29",
+        "W0_30"
+      ],
+      "Start": null,
+      "End": null
+    }
   }
 ]

--- a/tests/DocflowAi.Net.Api.Tests/DefaultJobSeederTests.cs
+++ b/tests/DocflowAi.Net.Api.Tests/DefaultJobSeederTests.cs
@@ -1,9 +1,11 @@
 using System.Collections.Generic;
 using System.Net.Http.Json;
+using System.Net.Http;
 using DocflowAi.Net.Api.Tests.Fixtures;
 using System.Linq;
 using System.Text.Json;
 using System.Net;
+using System.IO;
 
 namespace DocflowAi.Net.Api.Tests;
 
@@ -60,6 +62,113 @@ public class DefaultJobSeederTests : IClassFixture<TempDirFixture>
 
         var fileResp = await client.GetAsync(ok.GetProperty("paths").GetProperty("input").GetString());
         fileResp.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task Seeded_Jobs_Copy_Source_Files()
+    {
+        var extra = new Dictionary<string, string?>
+        {
+            ["JobQueue:SeedDefaults"] = "true"
+        };
+        using var factory = new TestWebAppFactory(_fixture.RootPath, extra: extra);
+        var client = factory.CreateClient();
+
+        var datasetRoot = FindDatasetRoot();
+
+        var ok = await client.GetFromJsonAsync<JsonElement>("/api/v1/jobs/11111111-1111-1111-1111-111111111111");
+        var okInput = ok.GetProperty("paths").GetProperty("input").GetString()!;
+        var okPrompt = ok.GetProperty("paths").GetProperty("prompt").GetString()!;
+        var okFields = ok.GetProperty("paths").GetProperty("fields").GetString()!;
+        var okOutput = ok.GetProperty("paths").GetProperty("output").GetString()!;
+        (await client.GetByteArrayAsync(okInput))
+            .Should().BeEquivalentTo(File.ReadAllBytes(Path.Combine(datasetRoot, "sample_invoice.pdf")));
+        (await client.GetStringAsync(okPrompt))
+            .Should().Be(File.ReadAllText(Path.Combine(datasetRoot, "test-pdf", "prompt.txt")));
+        (await client.GetStringAsync(okFields))
+            .Should().Be(File.ReadAllText(Path.Combine(datasetRoot, "test-pdf", "fields.txt")));
+        (await client.GetStringAsync(okOutput))
+            .Should().Be(File.ReadAllText(Path.Combine(datasetRoot, "test-png-boxsolver-pointerstrategy", "result.json")));
+
+        var err = await client.GetFromJsonAsync<JsonElement>("/api/v1/jobs/22222222-2222-2222-2222-222222222222");
+        var errInput = err.GetProperty("paths").GetProperty("input").GetString()!;
+        var errPrompt = err.GetProperty("paths").GetProperty("prompt").GetString()!;
+        var errFields = err.GetProperty("paths").GetProperty("fields").GetString()!;
+        var errError = err.GetProperty("paths").GetProperty("error").GetString()!;
+        (await client.GetByteArrayAsync(errInput))
+            .Should().BeEquivalentTo(File.ReadAllBytes(Path.Combine(datasetRoot, "sample_invoice.png")));
+        (await client.GetStringAsync(errPrompt))
+            .Should().Be(File.ReadAllText(Path.Combine(datasetRoot, "test-png", "prompt.txt")));
+        (await client.GetStringAsync(errFields))
+            .Should().Be(File.ReadAllText(Path.Combine(datasetRoot, "test-png", "fields.txt")));
+        (await client.GetStringAsync(errError))
+            .Should().Be(File.ReadAllText(Path.Combine(datasetRoot, "test-png", "llm_response.txt")));
+    }
+
+    [Fact]
+    public async Task Seeded_Job_Files_Return_Correct_Content_Types()
+    {
+        var extra = new Dictionary<string, string?>
+        {
+            ["JobQueue:SeedDefaults"] = "true"
+        };
+        using var factory = new TestWebAppFactory(_fixture.RootPath, extra: extra);
+        var client = factory.CreateClient();
+
+        var ok = await client.GetFromJsonAsync<JsonElement>("/api/v1/jobs/11111111-1111-1111-1111-111111111111");
+        var okPaths = ok.GetProperty("paths");
+        await AssertBinaryFile(client, okPaths.GetProperty("input").GetString()!, new byte[] { 0x25, 0x50, 0x44, 0x46 });
+        await AssertTextFile(client, okPaths.GetProperty("prompt").GetString()!);
+        await AssertTextFile(client, okPaths.GetProperty("fields").GetString()!);
+        await AssertJsonFile(client, okPaths.GetProperty("output").GetString()!);
+
+        var err = await client.GetFromJsonAsync<JsonElement>("/api/v1/jobs/22222222-2222-2222-2222-222222222222");
+        var errPaths = err.GetProperty("paths");
+        await AssertBinaryFile(client, errPaths.GetProperty("input").GetString()!, new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A });
+        await AssertTextFile(client, errPaths.GetProperty("prompt").GetString()!);
+        await AssertTextFile(client, errPaths.GetProperty("fields").GetString()!);
+        await AssertTextFile(client, errPaths.GetProperty("error").GetString()!);
+
+        static async Task AssertBinaryFile(HttpClient client, string path, byte[] signature)
+        {
+            var resp = await client.GetAsync(path);
+            resp.StatusCode.Should().Be(HttpStatusCode.OK);
+            var bytes = await resp.Content.ReadAsByteArrayAsync();
+            bytes.Length.Should().BeGreaterThan(signature.Length);
+            bytes.Take(signature.Length).Should().Equal(signature);
+        }
+
+        static async Task AssertTextFile(HttpClient client, string path)
+        {
+            var resp = await client.GetAsync(path);
+            resp.StatusCode.Should().Be(HttpStatusCode.OK);
+            resp.Content.Headers.ContentType!.MediaType.Should().Be("text/plain");
+            var text = await resp.Content.ReadAsStringAsync();
+            text.Should().NotBeNullOrWhiteSpace();
+        }
+
+        static async Task AssertJsonFile(HttpClient client, string path)
+        {
+            var resp = await client.GetAsync(path);
+            resp.StatusCode.Should().Be(HttpStatusCode.OK);
+            resp.Content.Headers.ContentType!.MediaType.Should().Be("application/json");
+            var text = await resp.Content.ReadAsStringAsync();
+            text.Should().NotBeNullOrWhiteSpace();
+            JsonDocument.Parse(text);
+        }
+    }
+
+    private static string FindDatasetRoot()
+    {
+        var dir = new DirectoryInfo(Directory.GetCurrentDirectory());
+        while (dir != null)
+        {
+            var path = Path.Combine(dir.FullName, "dataset");
+            if (Directory.Exists(path))
+                return path;
+            dir = dir.Parent;
+        }
+        throw new DirectoryNotFoundException("dataset");
     }
 
     private record JobListResponse(int page, int pageSize, int total, List<JobItem> items);


### PR DESCRIPTION
## Summary
- expand sample job seed result with item descriptions, prices, and total
- verify seeded jobs copy dataset artifacts
- ensure API serves seeded job files with correct content signatures and types

## Testing
- `rg -n -i 'pytest|:8000|sidecar|MarkitdownException|MARKITDOWN_URL|PY_MARKITDOWN_ENABLED' -g '!AGENTS.md'`
- `dotnet build -c Release`
- `dotnet test -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68a0b8e8ebbc8325befdb60bed875940