### PR TITLE
test: verify hangfire dashboard returns html

### DIFF
--- a/frontend/tests/hangfire.e2e.spec.ts
+++ b/frontend/tests/hangfire.e2e.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() =>
+    localStorage.setItem('apiKey', 'dev-secret-key-change-me'),
+  );
+});
+
+test('opens hangfire dashboard with api key', async ({ page, context }) => {
+  await context.route(
+    '**/hangfire?api_key=dev-secret-key-change-me',
+    (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'text/html',
+        body: '<html></html>',
+      }),
+  );
+  await page.goto('/jobs');
+  const [popup] = await Promise.all([
+    page.waitForEvent('popup'),
+    page.getByRole('menuitem', { name: 'Hangfire' }).click(),
+  ]);
+  await popup.waitForLoadState();
+  expect(popup.url()).toBe(
+    'http://localhost:5214/hangfire?api_key=dev-secret-key-change-me',
+  );
+  const html = await popup.content();
+  expect(html).toContain('<html');
+});

--- a/tests/DocflowAi.Net.Api.Tests/DashboardAuthTests.cs
+++ b/tests/DocflowAi.Net.Api.Tests/DashboardAuthTests.cs
@@ -28,7 +28,7 @@ public class DashboardAuthTests : IClassFixture<TempDirFixture>
     [Fact]
     public async Task Dashboard_allows_request_with_valid_api_key()
     {
-        var extra = new Dictionary<string,string?>
+        var extra = new Dictionary<string, string?>
         {
             ["JobQueue:EnableDashboard"] = "true",
             ["HangfireDashboardAuth:Enabled"] = "true",
@@ -38,5 +38,8 @@ public class DashboardAuthTests : IClassFixture<TempDirFixture>
         var client = factory.CreateClient();
         var resp = await client.GetAsync("/hangfire?api_key=k");
         resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        resp.Content.Headers.ContentType?.MediaType.Should().Be("text/html");
+        var content = await resp.Content.ReadAsStringAsync();
+        content.Should().Contain("<html", "dashboard should return HTML content");
     }
 }


### PR DESCRIPTION
## Summary
- ensure Hangfire dashboard returns HTML when accessed with a valid API key
- add Playwright E2E test covering Hangfire dashboard link

## Testing
- `rg -n -i 'pytest|:8000|sidecar|MarkitdownException|MARKITDOWN_URL|PY_MARKITDOWN_ENABLED' --glob '!AGENTS.md'`
- `dotnet build -c Release`
- `dotnet test -c Release`
- `npx --yes playwright install`
- `npx --yes playwright install-deps` *(partial)*
- `npm test -- --run`
- `npm run build`
- `npm run e2e`

------
https://chatgpt.com/codex/tasks/task_e_68a0dca41bc48325a54ae22b8d225bf1