### PR TITLE
Fix job file endpoint to use absolute paths

### DIFF
--- a/src/DocflowAi.Net.Api/JobQueue/Endpoints/JobEndpoints.cs
+++ b/src/DocflowAi.Net.Api/JobQueue/Endpoints/JobEndpoints.cs
@@ -91,9 +91,11 @@ public static class JobEndpoints
                 .Where(p => !string.IsNullOrEmpty(p));
             var match = candidates.FirstOrDefault(p => Path.GetFileName(p!)
                 .Equals(name, StringComparison.OrdinalIgnoreCase));
-            if (match == null || !File.Exists(match)) return Results.NotFound();
+            if (match == null) return Results.NotFound();
+            var path = Path.GetFullPath(match);
+            if (!File.Exists(path)) return Results.NotFound();
             var contentType = GetContentType(name);
-            return Results.File(match, contentType, name);
+            return Results.File(path, contentType, name);
         })
         .WithName("Jobs_File")
         .Produces(StatusCodes.Status200OK)


### PR DESCRIPTION
## Summary
- ensure job file downloads resolve to an absolute filesystem path

## Testing
- `rg -n -i 'pytest|:8000|sidecar|MarkitdownException|MARKITDOWN_URL|PY_MARKITDOWN_ENABLED'`
- `dotnet build -c Release`
- `dotnet test -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68a0e4e1b14083258514a9bb04f54bb1