### PR TITLE
Fix Hangfire link URL construction

### DIFF
--- a/frontend/src/hangfire.ts
+++ b/frontend/src/hangfire.ts
@@ -1,7 +1,8 @@
 export function openHangfire() {
-  const base = import.meta.env.VITE_API_BASE_URL || '';
-  const path = import.meta.env.VITE_HANGFIRE_PATH || '';
+  const base = import.meta.env.VITE_API_BASE_URL || window.location.origin;
+  const path = import.meta.env.VITE_HANGFIRE_PATH || '/hangfire';
   const apiKey = localStorage.getItem('apiKey');
-  const url = apiKey ? `${base}${path}?api_key=${encodeURIComponent(apiKey)}` : `${base}${path}`;
-  window.open(url, '_blank', 'noopener,noreferrer');
+  const url = new URL(path, base);
+  if (apiKey) url.searchParams.set('api_key', apiKey);
+  window.open(url.toString(), '_blank', 'noopener,noreferrer');
 }

--- a/frontend/tests/hangfire.e2e.spec.ts
+++ b/frontend/tests/hangfire.e2e.spec.ts
@@ -28,3 +28,37 @@ test('opens hangfire dashboard with api key', async ({ page, context }) => {
   const html = await popup.content();
   expect(html).toContain('<html');
 });
+
+test('opens hangfire from job detail page', async ({ page, context }) => {
+  await context.route(
+    '**/hangfire?api_key=dev-secret-key-change-me',
+    (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'text/html',
+        body: '<html></html>',
+      }),
+  );
+  await context.route('**/api/v1/jobs/1', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: '1',
+        status: 'Queued',
+        createdAt: '',
+        updatedAt: '',
+        attempts: 0,
+      }),
+    }),
+  );
+  await page.goto('/jobs/1');
+  const [popup] = await Promise.all([
+    page.waitForEvent('popup'),
+    page.getByRole('menuitem', { name: 'Hangfire' }).click(),
+  ]);
+  await popup.waitForLoadState();
+  expect(popup.url()).toBe(
+    'http://localhost:5214/hangfire?api_key=dev-secret-key-change-me',
+  );
+});


### PR DESCRIPTION
## Summary
- ensure Hangfire dashboard link uses absolute URL and API key query string
- test that Hangfire link opens correctly from nested routes

## Testing
- `rg -n -i 'pytest|:8000|sidecar|MarkitdownException|MARKITDOWN_URL|PY_MARKITDOWN_ENABLED' -g '!AGENTS.md'`
- `dotnet build -c Release`
- `dotnet test -c Release` *(fails: BBoxResolverTests.Performance_Smoke)*
- `npm test -- --run`
- `npm run build`
- `npm run e2e` *(fails: browsers missing / tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e536e56c83259f9659eb6281ddf2