### PR TITLE
feat: add centered loader

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, lazy, Suspense } from 'react';
+import Loader from './components/Loader';
 import { Routes, Route, Navigate } from 'react-router-dom';
 const Login = lazy(() => import('./pages/Login'));
 const Shell = lazy(() => import('./Shell'));
@@ -20,13 +21,13 @@ function App() {
   };
   if (!apiKey) {
     return (
-      <Suspense fallback={<div>Loading...</div>}>
+      <Suspense fallback={<Loader />}>
         <Login onLogin={handleLogin} />
       </Suspense>
     );
   }
   return (
-    <Suspense fallback={<div>Loading...</div>}>
+    <Suspense fallback={<Loader />}>
       <Routes>
         <Route path="/" element={<Shell />}>
           <Route index element={<Navigate to="/jobs" />} />

--- a/frontend/src/components/Loader.tsx
+++ b/frontend/src/components/Loader.tsx
@@ -1,0 +1,16 @@
+import LoadingOutlined from '@ant-design/icons/LoadingOutlined';
+
+export default function Loader() {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        height: '100vh',
+      }}
+    >
+      <LoadingOutlined aria-label="loading" style={{ fontSize: 48 }} spin />
+    </div>
+  );
+}

--- a/frontend/src/pages/JobDetail.tsx
+++ b/frontend/src/pages/JobDetail.tsx
@@ -10,6 +10,7 @@ import JobStatusTag from '../components/JobStatusTag';
 import MarkdownPreview from '@uiw/react-markdown-preview';
 import JsonView from '@uiw/react-json-view';
 import { githubLightTheme } from '@uiw/react-json-view/githubLight';
+import Loader from '../components/Loader';
 
 export default function JobDetail() {
   const { id } = useParams();
@@ -170,7 +171,7 @@ export default function JobDetail() {
     }
   };
 
-  if (!job) return <div>Loading...</div>;
+  if (!job) return <Loader />;
 
   const artifacts = Object.entries(job.paths || {})
     .filter(([k, v]) => v && (k !== 'error' || job.status !== 'Succeeded'))

--- a/frontend/tests/loader.e2e.spec.ts
+++ b/frontend/tests/loader.e2e.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() =>
+    localStorage.setItem('apiKey', 'dev-secret-key-change-me')
+  );
+});
+
+test('shows loader icon while job detail is loading', async ({ page }) => {
+  await page.route('**/jobs/1', async (route) => {
+    await new Promise((r) => setTimeout(r, 1000));
+    route.fulfill({
+      json: {
+        id: '1',
+        status: 'Succeeded',
+        derivedStatus: 'Completed',
+        progress: 100,
+        attempts: 1,
+        createdAt: '',
+        updatedAt: '',
+        paths: {},
+      },
+    });
+  });
+
+  await page.goto('/jobs/1', { waitUntil: 'domcontentloaded' });
+  await expect(page.getByLabel('loading')).toBeVisible();
+  await expect(page.getByText('Job 1')).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- show centered spinner icon while assets load
- add E2E test for loader

## Testing
- `dotnet build -c Release`
- `dotnet test -c Release`
- `rg -n -i 'pytest|:8000|sidecar|MarkitdownException|MARKITDOWN_URL|PY_MARKITDOWN_ENABLED'`
- `npx --yes playwright install`
- `npx --yes playwright install-deps` *(fails: Operation was interrupted before it could finish)*
- `npm test -- --run` *(fails: Operation was interrupted before it could finish)*
- `npm run build` *(not run)*
- `npm run e2e` *(not run)*

------
https://chatgpt.com/codex/tasks/task_e_68a17b66a33c832588c17309c15efc08