### PR TITLE
Show loader during lazy route load

### DIFF
--- a/frontend/src/Shell.tsx
+++ b/frontend/src/Shell.tsx
@@ -1,11 +1,13 @@
 import { Layout, Menu } from 'antd';
 import { useNavigate, Outlet, useLocation } from 'react-router-dom';
+import { Suspense } from 'react';
 import AppstoreOutlined from '@ant-design/icons/AppstoreOutlined';
 import FileAddOutlined from '@ant-design/icons/FileAddOutlined';
 import HeartOutlined from '@ant-design/icons/HeartOutlined';
 import LinkOutlined from '@ant-design/icons/LinkOutlined';
 import ExperimentOutlined from '@ant-design/icons/ExperimentOutlined';
 import HealthBadge from './components/HealthBadge';
+import Loader from './components/Loader';
 import { openHangfire } from './hangfire';
 
 const { Header, Content } = Layout;
@@ -49,7 +51,9 @@ export default function Shell() {
         <HealthBadge />
       </Header>
       <Content style={{ padding: 24 }}>
-        <Outlet />
+        <Suspense fallback={<Loader />}>
+          <Outlet />
+        </Suspense>
       </Content>
     </Layout>
   );

--- a/frontend/tests/loader.e2e.spec.ts
+++ b/frontend/tests/loader.e2e.spec.ts
@@ -27,3 +27,27 @@ test('shows loader icon while job detail is loading', async ({ page }) => {
   await expect(page.getByLabel('loading')).toBeVisible();
   await expect(page.getByText('Job 1')).toBeVisible();
 });
+
+test('shows loader while job detail chunk is loading', async ({ page }) => {
+  await page.route('**/JobDetail*.js', async (route) => {
+    await new Promise((r) => setTimeout(r, 1000));
+    await route.continue();
+  });
+  await page.route('**/jobs/1', (route) => {
+    route.fulfill({
+      json: {
+        id: '1',
+        status: 'Succeeded',
+        derivedStatus: 'Completed',
+        progress: 100,
+        attempts: 1,
+        createdAt: '',
+        updatedAt: '',
+        paths: {},
+      },
+    });
+  });
+  await page.goto('/jobs/1', { waitUntil: 'domcontentloaded' });
+  await expect(page.getByLabel('loading')).toBeVisible();
+  await expect(page.getByText('Job 1')).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- ensure nested routes display loader while lazy chunks load
- cover dynamic chunk loading with E2E test

## Testing
- `rg -n -i 'pytest|:8000|sidecar|MarkitdownException|MARKITDOWN_URL|PY_MARKITDOWN_ENABLED' -g '!AGENTS.md'`
- `dotnet build -c Release`
- `dotnet test -c Release`
- `npm test -- --run`
- `npm run build`
- `npm run e2e` *(failed: shows loader icon while job detail is loading; shows loader while job detail chunk is loading)*

------
https://chatgpt.com/codex/tasks/task_e_68a18ece1f24832581e3790bed5cb7b9