### PR TITLE
feat: add models and recognition routes

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,9 @@ const JobNew = lazy(() => import('./pages/JobNew'));
 const JobDetail = lazy(() => import('./pages/JobDetail'));
 const HealthPage = lazy(() => import('./pages/HealthPage'));
 const ModelManagerPage = lazy(() => import('./pages/ModelManagerPage'));
+const ModelsPage = lazy(() => import('./pages/ModelsPage'));
+const RecognizeRunPage = lazy(() => import('./pages/RecognizeRunPage'));
+const TemplatesPage = lazy(() => import('./pages/TemplatesPage'));
 import { OpenAPI } from './generated';
 
 function App() {
@@ -36,6 +39,9 @@ function App() {
           <Route path="jobs/:id" element={<JobDetail />} />
           <Route path="health" element={<HealthPage />} />
           <Route path="model" element={<ModelManagerPage />} />
+          <Route path="models" element={<ModelsPage />} />
+          <Route path="recognize-run" element={<RecognizeRunPage />} />
+          <Route path="templates" element={<TemplatesPage />} />
           <Route path="*" element={<Navigate to="/jobs" />} />
         </Route>
       </Routes>

--- a/frontend/src/Shell.tsx
+++ b/frontend/src/Shell.tsx
@@ -6,6 +6,9 @@ import FileAddOutlined from '@ant-design/icons/FileAddOutlined';
 import HeartOutlined from '@ant-design/icons/HeartOutlined';
 import LinkOutlined from '@ant-design/icons/LinkOutlined';
 import ExperimentOutlined from '@ant-design/icons/ExperimentOutlined';
+import DatabaseOutlined from '@ant-design/icons/DatabaseOutlined';
+import PlayCircleOutlined from '@ant-design/icons/PlayCircleOutlined';
+import ProfileOutlined from '@ant-design/icons/ProfileOutlined';
 import HealthBadge from './components/HealthBadge';
 import ChunkLoader from './components/ChunkLoader';
 import { openHangfire } from './hangfire';
@@ -19,6 +22,9 @@ export default function Shell() {
     { key: '/jobs', icon: <AppstoreOutlined />, label: 'Jobs' },
     { key: '/jobs/new', icon: <FileAddOutlined />, label: 'New Job' },
     { key: '/model', icon: <ExperimentOutlined />, label: 'Model' },
+    { key: '/models', icon: <DatabaseOutlined />, label: 'Models' },
+    { key: '/templates', icon: <ProfileOutlined />, label: 'Templates' },
+    { key: '/recognize-run', icon: <PlayCircleOutlined />, label: 'Recognize Run' },
     { key: '/health', icon: <HeartOutlined />, label: 'Health' },
     {
       key: 'hangfire',

--- a/frontend/tests/models.e2e.spec.ts
+++ b/frontend/tests/models.e2e.spec.ts
@@ -1,0 +1,12 @@
+import { test, expect } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() =>
+    localStorage.setItem('apiKey', 'dev-secret-key-change-me')
+  );
+});
+
+test('models page renders', async ({ page }) => {
+  await page.goto('/models');
+  await expect(page.getByText('GGUF Models')).toBeVisible();
+});

--- a/frontend/tests/recognize-run.e2e.spec.ts
+++ b/frontend/tests/recognize-run.e2e.spec.ts
@@ -1,0 +1,12 @@
+import { test, expect } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() =>
+    localStorage.setItem('apiKey', 'dev-secret-key-change-me')
+  );
+});
+
+test('recognize run page renders', async ({ page }) => {
+  await page.goto('/recognize-run');
+  await expect(page.getByText('Run Recognition with Template')).toBeVisible();
+});

--- a/frontend/tests/templates.e2e.spec.ts
+++ b/frontend/tests/templates.e2e.spec.ts
@@ -1,0 +1,12 @@
+import { test, expect } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() =>
+    localStorage.setItem('apiKey', 'dev-secret-key-change-me')
+  );
+});
+
+test('templates page renders', async ({ page }) => {
+  await page.goto('/templates');
+  await expect(page.getByText('Templates')).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- expose ModelsPage, RecognizeRunPage, and TemplatesPage via router
- surface pages in navigation menu with icons
- cover new pages with basic e2e checks

## Testing
- `rg -n -i 'pytest|:8000|sidecar|MarkitdownException|MARKITDOWN_URL|PY_MARKITDOWN_ENABLED' --glob '!AGENTS.md'`
- `dotnet build -c Release`
- `dotnet test -c Release`
- `npm test -- --run`
- `npm run build`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_68a23955ee44832586f4a1b03a11a0df