### PR TITLE
feat(frontend): show creation badges for models and templates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,7 @@ Prompts:
 - Every page must render flawlessly on mobile devices without horizontal scrolling.
 - When displaying tabular data, follow Ant Design's responsive table guidelines, switching to stacked lists on small screens when needed. See: https://ant.design/components/table/#responsive
 - Use clear icons to convey service health and other status information at a glance.
+- After creating a job, model, template, or any future entity in the frontend, display a green success badge with the message "<Entity> created successfully.".
 
 # Operations
 The native libraries of Tesseract (libtesseract.so.5) and Leptonica (liblept.so.5) are already present in `src/MarkItDownNet/TesseractOCR/x64` and are copied automatically next to the binaries. Installing system packages or creating symbolic links is not required.

--- a/frontend/src/components/ModelModal.test.tsx
+++ b/frontend/src/components/ModelModal.test.tsx
@@ -18,7 +18,7 @@ describe('ModelModal', () => {
   it('uses select for type', () => {
     render(
       <ApiErrorProvider>
-        <ModelModal open onCancel={() => {}} onSaved={() => {}} existingNames={[]} />
+        <ModelModal open onCancel={() => {}} onSaved={(created) => {}} existingNames={[]} />
       </ApiErrorProvider>,
     );
     const select = screen.getByLabelText('Type');
@@ -28,7 +28,7 @@ describe('ModelModal', () => {
   it('validates required fields', async () => {
     render(
       <ApiErrorProvider>
-        <ModelModal open onCancel={() => {}} onSaved={() => {}} existingNames={[]} />
+        <ModelModal open onCancel={() => {}} onSaved={(created) => {}} existingNames={[]} />
       </ApiErrorProvider>,
     );
     fireEvent.click(screen.getAllByRole('button', { name: 'Save' })[0]);

--- a/frontend/src/components/ModelModal.tsx
+++ b/frontend/src/components/ModelModal.tsx
@@ -7,7 +7,7 @@ interface ModelModalProps {
   open: boolean;
   modelId?: string;
   onCancel: () => void;
-  onSaved: () => void;
+  onSaved: (created: boolean) => void;
   existingNames: string[];
 }
 
@@ -60,6 +60,7 @@ export default function ModelModal({
           },
         });
         message.success('Model updated');
+        onSaved(false);
       } else {
         const req: CreateModelRequest = {
           name: values.name,
@@ -72,9 +73,9 @@ export default function ModelModal({
           hfToken: values.hfToken,
         };
         await ModelsService.modelsCreate({ requestBody: req });
-        message.success('Model created');
+        message.success('Model created successfully.');
+        onSaved(true);
       }
-      onSaved();
       onCancel();
     } catch (e) {
       if (!(e instanceof ApiError) && e instanceof Error) showError(e.message);

--- a/frontend/src/components/TemplateModal.test.tsx
+++ b/frontend/src/components/TemplateModal.test.tsx
@@ -31,6 +31,7 @@ vi.mock('antd', () => {
   ),
   Space: ({ children }: any) => <div>{children}</div>,
   Grid: { useBreakpoint },
+  message: { success: vi.fn() },
 };
 });
 

--- a/frontend/src/components/TemplateModal.tsx
+++ b/frontend/src/components/TemplateModal.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Modal, Input, Button, Space, Grid } from 'antd';
+import { Modal, Input, Button, Space, Grid, message } from 'antd';
 import MDEditor from '@uiw/react-md-editor';
 import TemplateFieldsEditor from './TemplateFieldsEditor';
 import type { FieldItem } from './FieldsEditor';
@@ -62,8 +62,10 @@ export default function TemplateModal({ open, templateId, onClose }: Props) {
     try {
       if (templateId) {
         await TemplatesService.templatesUpdate({ id: templateId, requestBody: payload });
+        message.success('Template updated');
       } else {
         await TemplatesService.templatesCreate({ requestBody: payload });
+        message.success('Template created successfully.');
       }
       onClose(true);
     } finally {

--- a/frontend/src/pages/JobDetail.test.tsx
+++ b/frontend/src/pages/JobDetail.test.tsx
@@ -51,6 +51,32 @@ test('detail viewers render and have download', async () => {
   expect(previews).toHaveLength(1);
   await previews[0].click();
   await screen.findByText((content) => content.includes('template'));
-  screen.getAllByLabelText('Close')[0].click();
+  const closeBtns = await screen.findAllByLabelText('Close');
+  closeBtns[0].click();
   expect(screen.queryByText('error')).toBeNull();
+});
+
+test('shows success badge for new job', async () => {
+  vi.spyOn(JobsService, 'jobsGetById').mockResolvedValue({
+    id: '1',
+    status: 'Queued',
+    createdAt: '',
+    updatedAt: '',
+    attempts: 0,
+    model: 'm',
+    templateToken: 't',
+  } as any);
+  vi.spyOn(ModelsService, 'modelsList').mockResolvedValue([]);
+  vi.spyOn(TemplatesService, 'templatesList').mockResolvedValue({ items: [] } as any);
+  vi.spyOn(global, 'fetch' as any).mockResolvedValue(new Response(''));
+  render(
+    <ApiErrorProvider>
+      <MemoryRouter initialEntries={[{ pathname: '/jobs/1', state: { newJob: true } }]}> 
+        <Routes>
+          <Route path="/jobs/:id" element={<JobDetail />} />
+        </Routes>
+      </MemoryRouter>
+    </ApiErrorProvider>,
+  );
+  await screen.findByText('Job created successfully.');
 });

--- a/frontend/src/pages/JobDetail.tsx
+++ b/frontend/src/pages/JobDetail.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router-dom';
 import { JobsService, type JobDetailResponse, OpenAPI, ApiError, ModelsService, TemplatesService } from '../generated';
-import { Descriptions, Progress, Button, message, Space, Modal, Tabs, Table } from 'antd';
+import { Badge, Descriptions, Progress, Button, message, Space, Modal, Tabs, Table } from 'antd';
 import ReloadOutlined from '@ant-design/icons/ReloadOutlined';
 import StopOutlined from '@ant-design/icons/StopOutlined';
 import FileSearchOutlined from '@ant-design/icons/FileSearchOutlined';
@@ -15,6 +15,7 @@ import { useApiError } from '../components/ApiErrorProvider';
 
 export default function JobDetail() {
   const { id } = useParams();
+  const location = useLocation();
   const [job, setJob] = useState<JobDetailResponse | null>(null);
   const [modelInfo, setModelInfo] = useState<any | null>(null);
   const [templateInfo, setTemplateInfo] = useState<any | null>(null);
@@ -240,6 +241,11 @@ export default function JobDetail() {
 
   return (
     <div>
+      {(location.state as any)?.newJob && (
+        <div style={{ marginBottom: 16 }}>
+          <Badge status="success" text="Job created successfully." />
+        </div>
+      )}
       <Descriptions title={`Job ${job.id}`} bordered column={1} size="small">
         <Descriptions.Item label="Status">
           <JobStatusTag status={job.status!} derived={job.derivedStatus} />

--- a/frontend/src/pages/JobNew.tsx
+++ b/frontend/src/pages/JobNew.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Alert, Button, Card, Checkbox, Form, Input, Upload, notification, Select } from 'antd';
+import { Alert, Badge, Button, Card, Checkbox, Form, Input, Upload, notification, Select } from 'antd';
 import InboxOutlined from '@ant-design/icons/InboxOutlined';
 import { ApiError, OpenAPI, ModelsService, TemplatesService } from '../generated';
 import { request as __request } from '../generated/core/request';
@@ -68,6 +68,7 @@ export default function JobNew() {
   const [idempotencyKey, setIdempotencyKey] = useState('');
   const [loading, setLoading] = useState(false);
   const [result, setResult] = useState<any | null>(null);
+  const [created, setCreated] = useState(false);
   const [retryAfter, setRetryAfter] = useState<number | null>(null);
   const navigate = useNavigate();
   const { showError } = useApiError();
@@ -109,12 +110,13 @@ export default function JobNew() {
       const data = await submitPayload(payload, immediate, idempotencyKey || undefined);
       if (data.status === 'Succeeded') {
         setResult(data);
+        setCreated(true);
       } else {
         notification.success({
-          message: 'Job created',
+          message: 'Job created successfully.',
           description: data.job_id,
         });
-        navigate(`/jobs/${data.job_id}`);
+        navigate(`/jobs/${data.job_id}`, { state: { newJob: true } });
       }
     } catch (e) {
       if (e instanceof ApiError) {
@@ -133,6 +135,11 @@ export default function JobNew() {
 
   return (
     <Card>
+      {created && (
+        <div style={{ marginBottom: 16 }}>
+          <Badge status="success" text="Job created successfully." />
+        </div>
+      )}
       {retryAfter !== null && (
         <Alert
           banner

--- a/frontend/src/pages/ModelsPage.test.tsx
+++ b/frontend/src/pages/ModelsPage.test.tsx
@@ -3,6 +3,11 @@ import { describe, it, expect, vi } from 'vitest';
 import ModelsPage from './ModelsPage';
 import { ModelsService } from '../generated';
 
+vi.mock('../components/ModelModal', () => ({
+  default: ({ onSaved, open }: any) =>
+    open ? <button onClick={() => onSaved(true)}>modal</button> : null,
+}));
+
 vi.mock('../generated', () => {
   const list = [
     {
@@ -51,7 +56,7 @@ vi.mock('../generated', () => {
 describe('ModelsPage', () => {
   it('filters by type', async () => {
     render(<ModelsPage />);
-    await screen.findByText('host');
+    await screen.findAllByText('host');
     const select = screen.getByRole('combobox');
     fireEvent.mouseDown(select);
     fireEvent.click(screen.getByTitle('Local'));
@@ -72,7 +77,7 @@ describe('ModelsPage', () => {
 
   it('shows actions for hosted model', async () => {
     render(<ModelsPage />);
-    await screen.findByText('host');
+    await screen.findAllByText('host');
     expect(screen.getByLabelText('Edit model')).toBeInTheDocument();
     expect(screen.getAllByLabelText('Delete model').length).toBeGreaterThan(0);
   });
@@ -82,6 +87,16 @@ describe('ModelsPage', () => {
     await screen.findAllByText('host');
     expect(screen.getAllByText('Created: 2024-01-01 00:00').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Updated: 2024-01-04 00:00').length).toBeGreaterThan(0);
+  });
+
+  it('shows success badge after model creation', async () => {
+    render(<ModelsPage />);
+    await screen.findAllByText('host');
+    fireEvent.click(screen.getAllByText('Create Model')[0]);
+    fireEvent.click(screen.getByText('modal'));
+    await waitFor(() =>
+      expect(screen.getByText('Model created successfully.')).toBeInTheDocument(),
+    );
   });
 });
 

--- a/frontend/src/pages/ModelsPage.tsx
+++ b/frontend/src/pages/ModelsPage.tsx
@@ -9,6 +9,7 @@ import {
   message,
   Grid,
   Popconfirm,
+  Badge,
 } from 'antd';
 import type { Breakpoint } from 'antd/es/_util/responsiveObserver';
 import PlusOutlined from '@ant-design/icons/PlusOutlined';
@@ -32,6 +33,7 @@ export default function ModelsPage() {
   const screens = Grid.useBreakpoint();
   const isMobile = !screens.md;
   const [logModel, setLogModel] = useState<string | null>(null);
+  const [created, setCreated] = useState(false);
 
   const load = async () => {
     setLoading(true);
@@ -156,6 +158,11 @@ export default function ModelsPage() {
 
   return (
     <div>
+      {created && (
+        <div style={{ marginBottom: 16 }}>
+          <Badge status="success" text="Model created successfully." />
+        </div>
+      )}
       <Space
         direction={isMobile ? 'vertical' : 'horizontal'}
         style={{ width: '100%', marginBottom: 16 }}
@@ -297,7 +304,10 @@ export default function ModelsPage() {
           open={modalOpen}
           modelId={modalId}
           onCancel={() => setModalOpen(false)}
-          onSaved={load}
+          onSaved={(isCreated) => {
+            if (isCreated) setCreated(true);
+            load();
+          }}
           existingNames={models.map((m) => m.name!).filter(Boolean) as string[]}
         />
       )}

--- a/frontend/src/pages/TemplatesList.test.tsx
+++ b/frontend/src/pages/TemplatesList.test.tsx
@@ -53,6 +53,7 @@ vi.mock('antd', () => {
       { Option: ({ value, children }: any) => <option value={value}>{children}</option> },
     ),
     message: { success: vi.fn() },
+    Badge: ({ text }: any) => <span>{text}</span>,
   };
 });
 
@@ -92,6 +93,7 @@ test('create edit delete flows', async () => {
   fireEvent.click(screen.getByText('Create Template'));
   fireEvent.click(screen.getByText('modal'));
   await waitFor(() => expect(listSpy).toHaveBeenCalledTimes(5));
+  await screen.findByText('Template created successfully.');
 });
 
 test('renders list on mobile', async () => {

--- a/frontend/src/pages/TemplatesList.tsx
+++ b/frontend/src/pages/TemplatesList.tsx
@@ -11,6 +11,7 @@ import {
   Form,
   Select,
   Popconfirm,
+  Badge,
 } from 'antd';
 import PlusOutlined from '@ant-design/icons/PlusOutlined';
 import EditOutlined from '@ant-design/icons/EditOutlined';
@@ -31,6 +32,7 @@ export default function TemplatesList() {
   const [q, setQ] = useState('');
   const [sort, setSort] = useState('createdAt desc');
   const [modalId, setModalId] = useState<string | undefined>();
+  const [created, setCreated] = useState(false);
   const screens = Grid.useBreakpoint();
   const isMobile = !screens.md;
   const { showError } = useApiError();
@@ -117,6 +119,11 @@ export default function TemplatesList() {
 
   return (
     <div>
+      {created && (
+        <div style={{ marginBottom: 16 }}>
+          <Badge status="success" text="Template created successfully." />
+        </div>
+      )}
       <Space
         direction={isMobile ? 'vertical' : 'horizontal'}
         style={{ width: '100%', marginBottom: 16 }}
@@ -214,8 +221,12 @@ export default function TemplatesList() {
           open={true}
           templateId={modalId === 'new' ? undefined : modalId}
           onClose={(changed) => {
+            const wasNew = modalId === 'new';
             setModalId(undefined);
-            if (changed) load();
+            if (changed) {
+              if (wasNew) setCreated(true);
+              load();
+            }
           }}
         />
       )}


### PR DESCRIPTION
## Summary
- show success badges when creating models or templates
- propagate creation state from modals to list pages
- add tests and guidelines for future features

## Testing
- `rg -n -i 'pytest|:8000|sidecar|MarkitdownException|MARKITDOWN_URL|PY_MARKITDOWN_ENABLED'`
- `dotnet build -c Release`
- `dotnet test -c Release`
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3bd01416c8325ab9492fe4e1aa83c