### PR TITLE
feat: centralize notifications for CRUD

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,8 @@ Prompts:
 - Every page must render flawlessly on mobile devices without horizontal scrolling.
 - When displaying tabular data, follow Ant Design's responsive table guidelines, switching to stacked lists on small screens when needed. See: https://ant.design/components/table/#responsive
 - Use clear icons to convey service health and other status information at a glance.
+- After creating a job, model, template, or any future entity in the frontend, display a green success badge with the message "<Entity> created successfully.".
+- Use the shared notification component to show a green success notification for create, update, or delete actions and a red notification on errors.
 
 # Operations
 The native libraries of Tesseract (libtesseract.so.5) and Leptonica (liblept.so.5) are already present in `src/MarkItDownNet/TesseractOCR/x64` and are copied automatically next to the binaries. Installing system packages or creating symbolic links is not required.

--- a/frontend/src/components/ApiErrorProvider.test.tsx
+++ b/frontend/src/components/ApiErrorProvider.test.tsx
@@ -1,9 +1,13 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import ApiErrorProvider from './ApiErrorProvider';
+import { notify } from './notification';
+
+const { mockNotify } = vi.hoisted(() => ({ mockNotify: vi.fn() }));
+vi.mock('./notification', () => ({ notify: mockNotify, default: mockNotify }));
 
 describe('ApiErrorProvider', () => {
-  it('shows badge on fetch error', async () => {
+  it('shows notification on fetch error', async () => {
     const originalFetch = global.fetch;
     global.fetch = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ message: 'Oops' }), {
@@ -18,7 +22,7 @@ describe('ApiErrorProvider', () => {
     );
     await fetch('/api/test');
     await waitFor(() => {
-      expect(screen.getByText('Oops')).toBeInTheDocument();
+      expect(notify).toHaveBeenCalledWith('error', 'Oops');
     });
     global.fetch = originalFetch;
   });

--- a/frontend/src/components/ApiErrorProvider.tsx
+++ b/frontend/src/components/ApiErrorProvider.tsx
@@ -1,5 +1,5 @@
-import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
-import { Badge, Space } from 'antd';
+import { createContext, useContext, useEffect, type ReactNode } from 'react';
+import notify from './notification';
 
 interface ErrorContextValue {
   showError: (message: string) => void;
@@ -10,14 +10,7 @@ const ErrorContext = createContext<ErrorContextValue>({
 });
 
 export function ApiErrorProvider({ children }: { children: ReactNode }) {
-  const [errors, setErrors] = useState<string[]>([]);
-
-  const showError = (msg: string) => {
-    setErrors((prev) => [...prev, msg]);
-    setTimeout(() => {
-      setErrors((prev) => prev.slice(1));
-    }, 5000);
-  };
+  const showError = (msg: string) => notify('error', msg);
 
   useEffect(() => {
     const originalFetch = window.fetch;
@@ -31,7 +24,7 @@ export function ApiErrorProvider({ children }: { children: ReactNode }) {
         } catch {
           // ignore
         }
-        showError(msg);
+        notify('error', msg);
       }
       return res;
     };
@@ -40,18 +33,7 @@ export function ApiErrorProvider({ children }: { children: ReactNode }) {
     };
   }, []);
 
-  return (
-    <ErrorContext.Provider value={{ showError }}>
-      {children}
-      <div style={{ position: 'fixed', top: 16, right: 16, zIndex: 1000 }}>
-        <Space direction="vertical">
-          {errors.map((e, i) => (
-            <Badge key={i} status="error" text={e} />
-          ))}
-        </Space>
-      </div>
-    </ErrorContext.Provider>
-  );
+  return <ErrorContext.Provider value={{ showError }}>{children}</ErrorContext.Provider>;
 }
 
 export function useApiError() {

--- a/frontend/src/components/ModelModal.test.tsx
+++ b/frontend/src/components/ModelModal.test.tsx
@@ -1,6 +1,9 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 
+const { mockNotify } = vi.hoisted(() => ({ mockNotify: vi.fn() }));
+vi.mock('./notification', () => ({ default: mockNotify, notify: mockNotify }));
+
 vi.mock('../generated', () => ({
   ModelsService: {
     modelsCreate: vi.fn().mockResolvedValue({}),
@@ -18,7 +21,7 @@ describe('ModelModal', () => {
   it('uses select for type', () => {
     render(
       <ApiErrorProvider>
-        <ModelModal open onCancel={() => {}} onSaved={() => {}} existingNames={[]} />
+        <ModelModal open onCancel={() => {}} onSaved={(created) => {}} existingNames={[]} />
       </ApiErrorProvider>,
     );
     const select = screen.getByLabelText('Type');
@@ -28,12 +31,10 @@ describe('ModelModal', () => {
   it('validates required fields', async () => {
     render(
       <ApiErrorProvider>
-        <ModelModal open onCancel={() => {}} onSaved={() => {}} existingNames={[]} />
+        <ModelModal open onCancel={() => {}} onSaved={(created) => {}} existingNames={[]} />
       </ApiErrorProvider>,
     );
     fireEvent.click(screen.getAllByRole('button', { name: 'Save' })[0]);
     expect(await screen.findByText('Name is required')).toBeInTheDocument();
   });
-
 });
-

--- a/frontend/src/components/ModelModal.tsx
+++ b/frontend/src/components/ModelModal.tsx
@@ -1,13 +1,14 @@
 import { useEffect, useState } from 'react';
-import { Modal, Form, Input, Select, Button, Space, message } from 'antd';
+import { Modal, Form, Input, Select, Button, Space } from 'antd';
 import { ModelsService, type CreateModelRequest, type ModelDto, ApiError } from '../generated';
 import { useApiError } from './ApiErrorProvider';
+import notify from './notification';
 
 interface ModelModalProps {
   open: boolean;
   modelId?: string;
   onCancel: () => void;
-  onSaved: () => void;
+  onSaved: (created: boolean) => void;
   existingNames: string[];
 }
 
@@ -59,7 +60,8 @@ export default function ModelModal({
             apiKey: updateKey ? values.apiKey : undefined,
           },
         });
-        message.success('Model updated');
+        notify('success', 'Model updated');
+        onSaved(false);
       } else {
         const req: CreateModelRequest = {
           name: values.name,
@@ -72,9 +74,9 @@ export default function ModelModal({
           hfToken: values.hfToken,
         };
         await ModelsService.modelsCreate({ requestBody: req });
-        message.success('Model created');
+        notify('success', 'Model created successfully.');
+        onSaved(true);
       }
-      onSaved();
       onCancel();
     } catch (e) {
       if (!(e instanceof ApiError) && e instanceof Error) showError(e.message);
@@ -132,10 +134,10 @@ export default function ModelModal({
         </Form.Item>
         {type === 'hosted-llm' && (
           <>
-            <Form.Item name="provider" label="Provider" rules={[{ required: true }]}>
+            <Form.Item name="provider" label="Provider" rules={[{ required: true }]}> 
               <Select options={[{ value: 'openai', label: 'openai' }, { value: 'azure-openai', label: 'azure-openai' }]} />
             </Form.Item>
-            <Form.Item name="baseUrl" label="Base URL" rules={[{ required: true, type: 'url' }]}>
+            <Form.Item name="baseUrl" label="Base URL" rules={[{ required: true, type: 'url' }]}> 
               <Input />
             </Form.Item>
             {editing && initial?.hasApiKey && (

--- a/frontend/src/components/TemplateModal.test.tsx
+++ b/frontend/src/components/TemplateModal.test.tsx
@@ -2,6 +2,10 @@ import { render, fireEvent, screen, waitFor, cleanup } from '@testing-library/re
 import { test, expect, vi, afterEach } from 'vitest';
 import TemplateModal from './TemplateModal';
 import { TemplatesService } from '../generated';
+import { notify } from './notification';
+
+const { mockNotify } = vi.hoisted(() => ({ mockNotify: vi.fn() }));
+vi.mock('./notification', () => ({ notify: mockNotify, default: mockNotify }));
 
 var useBreakpoint: any;
 vi.mock('antd', () => {
@@ -78,8 +82,8 @@ test('create flow', async () => {
   fireEvent.click(screen.getByText('add'));
   fireEvent.click(screen.getByText('Save'));
   expect(createSpy).toHaveBeenCalled();
-  expect(onClose).not.toHaveBeenCalled();
   await waitFor(() => expect(onClose).toHaveBeenCalledWith(true));
+  expect(notify).toHaveBeenCalledWith('success', 'Template created successfully.');
   expect(createSpy.mock.calls[0][0].requestBody.fieldsJson).toEqual({
     fields: [{ name: 'k', type: 'string' }],
   });
@@ -100,6 +104,7 @@ test('update flow', async () => {
   fireEvent.change(screen.getByPlaceholderText('Template Token'), { target: { value: 'b' } });
   fireEvent.click(screen.getByText('Save'));
   await waitFor(() => expect(updateSpy).toHaveBeenCalled());
+  expect(notify).toHaveBeenCalledWith('success', 'Template updated');
 });
 
 test('does not show timestamps on edit', async () => {

--- a/frontend/src/components/TemplateModal.tsx
+++ b/frontend/src/components/TemplateModal.tsx
@@ -6,6 +6,7 @@ import type { FieldItem } from './FieldsEditor';
 import { fieldsToJson, jsonToFields } from './FieldsEditor';
 import { slugify, isSlug } from '../templates/slug';
 import { TemplatesService } from '../generated';
+import notify from './notification';
 
 interface Props {
   open: boolean;
@@ -62,8 +63,10 @@ export default function TemplateModal({ open, templateId, onClose }: Props) {
     try {
       if (templateId) {
         await TemplatesService.templatesUpdate({ id: templateId, requestBody: payload });
+        notify('success', 'Template updated');
       } else {
         await TemplatesService.templatesCreate({ requestBody: payload });
+        notify('success', 'Template created successfully.');
       }
       onClose(true);
     } finally {

--- a/frontend/src/components/notification.test.ts
+++ b/frontend/src/components/notification.test.ts
@@ -1,0 +1,18 @@
+import { vi, test, expect } from 'vitest';
+import { notify } from './notification';
+import { notification } from 'antd';
+
+vi.mock('antd', () => ({
+  notification: {
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+
+test('notify forwards to antd notification', () => {
+  notify('success', 'ok');
+  expect(notification.success).toHaveBeenCalledWith({ message: 'ok', description: undefined });
+  notify('error', 'fail', 'bad');
+  expect(notification.error).toHaveBeenCalledWith({ message: 'fail', description: 'bad' });
+});

--- a/frontend/src/components/notification.ts
+++ b/frontend/src/components/notification.ts
@@ -1,0 +1,13 @@
+import { notification } from 'antd';
+
+export type AppNotificationType = 'success' | 'error' | 'warning';
+
+export function notify(
+  type: AppNotificationType,
+  message: string,
+  description?: string,
+): void {
+  notification[type]({ message, description });
+}
+
+export default notify;

--- a/frontend/src/pages/JobDetail.test.tsx
+++ b/frontend/src/pages/JobDetail.test.tsx
@@ -51,6 +51,32 @@ test('detail viewers render and have download', async () => {
   expect(previews).toHaveLength(1);
   await previews[0].click();
   await screen.findByText((content) => content.includes('template'));
-  screen.getAllByLabelText('Close')[0].click();
+  const closeBtns = await screen.findAllByLabelText('Close');
+  closeBtns[0].click();
   expect(screen.queryByText('error')).toBeNull();
+});
+
+test('shows success badge for new job', async () => {
+  vi.spyOn(JobsService, 'jobsGetById').mockResolvedValue({
+    id: '1',
+    status: 'Queued',
+    createdAt: '',
+    updatedAt: '',
+    attempts: 0,
+    model: 'm',
+    templateToken: 't',
+  } as any);
+  vi.spyOn(ModelsService, 'modelsList').mockResolvedValue([]);
+  vi.spyOn(TemplatesService, 'templatesList').mockResolvedValue({ items: [] } as any);
+  vi.spyOn(global, 'fetch' as any).mockResolvedValue(new Response(''));
+  render(
+    <ApiErrorProvider>
+      <MemoryRouter initialEntries={[{ pathname: '/jobs/1', state: { newJob: true } }]}> 
+        <Routes>
+          <Route path="/jobs/:id" element={<JobDetail />} />
+        </Routes>
+      </MemoryRouter>
+    </ApiErrorProvider>,
+  );
+  await screen.findByText('Job created successfully.');
 });

--- a/frontend/src/pages/JobDetail.tsx
+++ b/frontend/src/pages/JobDetail.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router-dom';
 import { JobsService, type JobDetailResponse, OpenAPI, ApiError, ModelsService, TemplatesService } from '../generated';
-import { Descriptions, Progress, Button, message, Space, Modal, Tabs, Table } from 'antd';
+import { Badge, Descriptions, Progress, Button, Space, Modal, Tabs, Table } from 'antd';
 import ReloadOutlined from '@ant-design/icons/ReloadOutlined';
 import StopOutlined from '@ant-design/icons/StopOutlined';
 import FileSearchOutlined from '@ant-design/icons/FileSearchOutlined';
 import DownloadOutlined from '@ant-design/icons/DownloadOutlined';
 import JobStatusTag from '../components/JobStatusTag';
+import notify from '../components/notification';
 import MarkdownPreview from '@uiw/react-markdown-preview';
 import JsonView from '@uiw/react-json-view';
 import { githubLightTheme } from '@uiw/react-json-view/githubLight';
@@ -15,6 +16,7 @@ import { useApiError } from '../components/ApiErrorProvider';
 
 export default function JobDetail() {
   const { id } = useParams();
+  const location = useLocation();
   const [job, setJob] = useState<JobDetailResponse | null>(null);
   const [modelInfo, setModelInfo] = useState<any | null>(null);
   const [templateInfo, setTemplateInfo] = useState<any | null>(null);
@@ -132,7 +134,7 @@ export default function JobDetail() {
     if (!id) return;
     try {
       await JobsService.jobsDelete({ id });
-      message.success('Job canceled');
+      notify('success', 'Job canceled');
       load();
     } catch (e) {
       if (e instanceof ApiError) {
@@ -240,6 +242,11 @@ export default function JobDetail() {
 
   return (
     <div>
+      {(location.state as any)?.newJob && (
+        <div style={{ marginBottom: 16 }}>
+          <Badge status="success" text="Job created successfully." />
+        </div>
+      )}
       <Descriptions title={`Job ${job.id}`} bordered column={1} size="small">
         <Descriptions.Item label="Status">
           <JobStatusTag status={job.status!} derived={job.derivedStatus} />

--- a/frontend/src/pages/JobsList.test.tsx
+++ b/frontend/src/pages/JobsList.test.tsx
@@ -4,6 +4,10 @@ import { MemoryRouter } from 'react-router-dom';
 import JobsList from './JobsList';
 import { JobsService } from '../generated';
 import ApiErrorProvider from '../components/ApiErrorProvider';
+import { notify } from '../components/notification';
+
+const { mockNotify } = vi.hoisted(() => ({ mockNotify: vi.fn() }));
+vi.mock('../components/notification', () => ({ notify: mockNotify, default: mockNotify }));
 
 vi.mock('antd', () => ({
   Table: ({ dataSource, pagination, columns }: any) => (
@@ -31,7 +35,6 @@ vi.mock('antd', () => ({
   Badge: () => <div />,
   Alert: () => null,
   Space: ({ children }: any) => <div>{children}</div>,
-  message: { success: vi.fn(), error: vi.fn() },
 }));
 
 test('pagination and cancel', async () => {
@@ -51,4 +54,5 @@ test('pagination and cancel', async () => {
   await waitFor(() => expect(getSpy).toHaveBeenLastCalledWith({ page: 2, pageSize: 10 }));
   fireEvent.click(screen.getByTitle('Cancel job'));
   await waitFor(() => expect(cancelSpy).toHaveBeenCalledWith({ id: '1' }));
+  expect(notify).toHaveBeenCalledWith('success', 'Job canceled');
 });

--- a/frontend/src/pages/JobsList.tsx
+++ b/frontend/src/pages/JobsList.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Table, Space, Button, Progress, Badge, Alert, message, List, Grid } from 'antd';
+import { Table, Space, Button, Progress, Badge, Alert, List, Grid } from 'antd';
 import FileAddOutlined from '@ant-design/icons/FileAddOutlined';
 import EyeOutlined from '@ant-design/icons/EyeOutlined';
 import StopOutlined from '@ant-design/icons/StopOutlined';
@@ -8,6 +8,7 @@ import FileExclamationOutlined from '@ant-design/icons/FileExclamationOutlined';
 import type { ColumnsType, TablePaginationConfig } from 'antd/es/table';
 import { JobsService, type JobDetailResponse, ApiError } from '../generated';
 import JobStatusTag from '../components/JobStatusTag';
+import notify from '../components/notification';
 import { Link } from 'react-router-dom';
 import dayjs from 'dayjs';
 import type { PaginationProps } from 'antd';
@@ -72,7 +73,7 @@ export default function JobsList() {
   const handleCancel = async (id: string) => {
     try {
       await JobsService.jobsDelete({ id });
-      message.success('Job canceled');
+      notify('success', 'Job canceled');
       load();
     } catch (e) {
       if (e instanceof ApiError) {

--- a/frontend/src/pages/ModelManagerPage.tsx
+++ b/frontend/src/pages/ModelManagerPage.tsx
@@ -5,7 +5,6 @@ import {
   Card,
   Descriptions,
   Alert,
-  message,
   Grid,
   Progress,
   Result,
@@ -13,6 +12,7 @@ import {
 } from 'antd';
 import ModelDownloadForm from '../components/ModelDownloadForm';
 import RetryAfterBanner from '../components/RetryAfterBanner';
+import notify from '../components/notification';
 import ModelSwitchSelect from '../components/ModelSwitchSelect';
 import {
   ModelService,
@@ -63,7 +63,7 @@ export default function ModelManagerPage() {
   const handleSwitch = async (file: string, ctx: number) => {
     try {
       await ModelService.modelSwitch({ requestBody: { modelFile: file, contextSize: ctx } });
-      message.success('Model activated');
+      notify('success', 'Model activated');
       await loadInfo();
     } catch (e) {
       if (e instanceof ApiError) {
@@ -77,7 +77,7 @@ export default function ModelManagerPage() {
   const handleDownload = async (req: DownloadModelRequest) => {
     try {
       await ModelService.modelDownload({ requestBody: req });
-      message.success('Download started');
+      notify('success', 'Download started');
       setStatus(null);
       setPolling(true);
     } catch (e) {
@@ -95,7 +95,7 @@ export default function ModelManagerPage() {
       setStatus(s);
       if (s.completed) {
         setPolling(false);
-        message.success('Download completed');
+        notify('success', 'Download completed');
         await loadAvailable();
       }
     } catch (e) {

--- a/frontend/src/pages/ModelsPage.tsx
+++ b/frontend/src/pages/ModelsPage.tsx
@@ -6,9 +6,9 @@ import {
   Input,
   Select,
   Space,
-  message,
   Grid,
   Popconfirm,
+  Badge,
 } from 'antd';
 import type { Breakpoint } from 'antd/es/_util/responsiveObserver';
 import PlusOutlined from '@ant-design/icons/PlusOutlined';
@@ -20,6 +20,7 @@ import ModelModal from '../components/ModelModal';
 import ModelLogModal from '../components/ModelLogModal';
 import { ModelsService, type ModelDto } from '../generated';
 import dayjs from 'dayjs';
+import notify from '../components/notification';
 
 export default function ModelsPage() {
   const [models, setModels] = useState<ModelDto[]>([]);
@@ -32,6 +33,7 @@ export default function ModelsPage() {
   const screens = Grid.useBreakpoint();
   const isMobile = !screens.md;
   const [logModel, setLogModel] = useState<string | null>(null);
+  const [created, setCreated] = useState(false);
 
   const load = async () => {
     setLoading(true);
@@ -114,7 +116,7 @@ export default function ModelsPage() {
               title="Delete model?"
               onConfirm={async () => {
                 await ModelsService.modelsDelete({ id: record.id! });
-                message.success('Model deleted');
+                notify('success', 'Model deleted');
                 load();
               }}
             >
@@ -128,7 +130,7 @@ export default function ModelsPage() {
                 aria-label="Start download"
                 onClick={async () => {
                   await ModelsService.modelsStartDownload({ id: record.id! });
-                  message.success('Download started');
+                  notify('success', 'Download started');
                   load();
                 }}
               />
@@ -141,7 +143,7 @@ export default function ModelsPage() {
                 title="Delete model?"
                 onConfirm={async () => {
                   await ModelsService.modelsDelete({ id: record.id! });
-                  message.success('Model deleted');
+                  notify('success', 'Model deleted');
                   load();
                 }}
               >
@@ -156,6 +158,11 @@ export default function ModelsPage() {
 
   return (
     <div>
+      {created && (
+        <div style={{ marginBottom: 16 }}>
+          <Badge status="success" text="Model created successfully." />
+        </div>
+      )}
       <Space
         direction={isMobile ? 'vertical' : 'horizontal'}
         style={{ width: '100%', marginBottom: 16 }}
@@ -207,7 +214,7 @@ export default function ModelsPage() {
                         aria-label="Start download"
                         onClick={async () => {
                           await ModelsService.modelsStartDownload({ id: r.id! });
-                          message.success('Download started');
+                          notify('success', 'Download started');
                           load();
                         }}
                       />,
@@ -222,7 +229,7 @@ export default function ModelsPage() {
                         title="Delete model?"
                         onConfirm={async () => {
                           await ModelsService.modelsDelete({ id: r.id! });
-                          message.success('Model deleted');
+                          notify('success', 'Model deleted');
                           load();
                         }}
                       >
@@ -244,7 +251,7 @@ export default function ModelsPage() {
                         title="Delete model?"
                         onConfirm={async () => {
                           await ModelsService.modelsDelete({ id: r.id! });
-                          message.success('Model deleted');
+                          notify('success', 'Model deleted');
                           load();
                         }}
                       >
@@ -297,7 +304,10 @@ export default function ModelsPage() {
           open={modalOpen}
           modelId={modalId}
           onCancel={() => setModalOpen(false)}
-          onSaved={load}
+          onSaved={(isCreated) => {
+            if (isCreated) setCreated(true);
+            load();
+          }}
           existingNames={models.map((m) => m.name!).filter(Boolean) as string[]}
         />
       )}
@@ -311,4 +321,3 @@ export default function ModelsPage() {
     </div>
   );
 }
-

--- a/frontend/src/pages/TemplatesList.test.tsx
+++ b/frontend/src/pages/TemplatesList.test.tsx
@@ -4,6 +4,10 @@ import { MemoryRouter } from 'react-router-dom';
 import TemplatesList from './TemplatesList';
 import { TemplatesService } from '../generated';
 import ApiErrorProvider from '../components/ApiErrorProvider';
+import { notify } from '../components/notification';
+
+const { mockNotify } = vi.hoisted(() => ({ mockNotify: vi.fn() }));
+vi.mock('../components/notification', () => ({ notify: mockNotify, default: mockNotify }));
 
 vi.mock('../components/TemplateModal', () => ({
   default: ({ onClose }: any) => <button onClick={() => onClose(true)}>modal</button>,
@@ -52,7 +56,7 @@ vi.mock('antd', () => {
       ),
       { Option: ({ value, children }: any) => <option value={value}>{children}</option> },
     ),
-    message: { success: vi.fn() },
+    Badge: ({ text }: any) => <span>{text}</span>,
   };
 });
 
@@ -88,10 +92,12 @@ test('create edit delete flows', async () => {
   await waitFor(() => expect(listSpy).toHaveBeenCalledTimes(3));
   fireEvent.click(screen.getAllByLabelText('Delete')[0]);
   await waitFor(() => expect(delSpy).toHaveBeenCalledWith({ id: '1' }));
+  expect(notify).toHaveBeenCalledWith('success', 'Template deleted');
   await waitFor(() => expect(listSpy).toHaveBeenCalledTimes(4));
   fireEvent.click(screen.getByText('Create Template'));
   fireEvent.click(screen.getByText('modal'));
   await waitFor(() => expect(listSpy).toHaveBeenCalledTimes(5));
+  await screen.findByText('Template created successfully.');
 });
 
 test('renders list on mobile', async () => {

--- a/frontend/src/pages/TemplatesList.tsx
+++ b/frontend/src/pages/TemplatesList.tsx
@@ -7,10 +7,10 @@ import {
   Space,
   Input,
   Typography,
-  message,
   Form,
   Select,
   Popconfirm,
+  Badge,
 } from 'antd';
 import PlusOutlined from '@ant-design/icons/PlusOutlined';
 import EditOutlined from '@ant-design/icons/EditOutlined';
@@ -20,6 +20,7 @@ import dayjs from 'dayjs';
 import { TemplatesService, type TemplateSummary } from '../generated';
 import TemplateModal from '../components/TemplateModal';
 import { useApiError } from '../components/ApiErrorProvider';
+import notify from '../components/notification';
 
 export default function TemplatesList() {
   const [templates, setTemplates] = useState<TemplateSummary[]>([]);
@@ -31,6 +32,7 @@ export default function TemplatesList() {
   const [q, setQ] = useState('');
   const [sort, setSort] = useState('createdAt desc');
   const [modalId, setModalId] = useState<string | undefined>();
+  const [created, setCreated] = useState(false);
   const screens = Grid.useBreakpoint();
   const isMobile = !screens.md;
   const { showError } = useApiError();
@@ -88,7 +90,7 @@ export default function TemplatesList() {
             onConfirm={async () => {
               try {
                 await TemplatesService.templatesDelete({ id: record.id! });
-                message.success('Template deleted');
+                notify('success', 'Template deleted');
                 load();
               } catch (e: any) {
                 if (e instanceof Error) showError(e.message);
@@ -117,6 +119,11 @@ export default function TemplatesList() {
 
   return (
     <div>
+      {created && (
+        <div style={{ marginBottom: 16 }}>
+          <Badge status="success" text="Template created successfully." />
+        </div>
+      )}
       <Space
         direction={isMobile ? 'vertical' : 'horizontal'}
         style={{ width: '100%', marginBottom: 16 }}
@@ -182,7 +189,7 @@ export default function TemplatesList() {
                   onConfirm={async () => {
                     try {
                       await TemplatesService.templatesDelete({ id: item.id! });
-                      message.success('Template deleted');
+                      notify('success', 'Template deleted');
                       load();
                     } catch (e: any) {
                       if (e instanceof Error) showError(e.message);
@@ -214,8 +221,12 @@ export default function TemplatesList() {
           open={true}
           templateId={modalId === 'new' ? undefined : modalId}
           onClose={(changed) => {
+            const wasNew = modalId === 'new';
             setModalId(undefined);
-            if (changed) load();
+            if (changed) {
+              if (wasNew) setCreated(true);
+              load();
+            }
           }}
         />
       )}


### PR DESCRIPTION
## Summary
- add reusable notification helper for success, error, and warning toasts
- swap legacy message calls for centralized notifications across job, model, and template flows
- document notification requirements for future features

## Testing
- `rg -n -i 'pytest|:8000|sidecar|MarkitdownException|MARKITDOWN_URL|PY_MARKITDOWN_ENABLED'`
- `dotnet build -c Release`
- `dotnet test -c Release`
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3bd01416c8325ab9492fe4e1aa83c