### PR TITLE
feat: enable Hangfire console logging

### DIFF
--- a/src/DocflowAi.Net.Api/DocflowAi.Net.Api.csproj
+++ b/src/DocflowAi.Net.Api/DocflowAi.Net.Api.csproj
@@ -34,6 +34,8 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0" />
     <PackageReference Include="Polly" Version="8.3.1" />
     <PackageReference Include="Hangfire.Console" Version="1.4.2" />
+    <PackageReference Include="Hangfire.Console.Extensions" Version="2.0.0" />
+    <PackageReference Include="Hangfire.Console.Extensions.Serilog" Version="2.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />

--- a/src/DocflowAi.Net.Api/Program.cs
+++ b/src/DocflowAi.Net.Api/Program.cs
@@ -43,6 +43,7 @@ using System.Collections.Generic;
 using Hangfire.Dashboard;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using DocflowAi.Net.Infrastructure.Security;
+using Hangfire.Console.Extensions;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -137,6 +138,7 @@ builder.Services.AddHangfire(config =>
           .UseRecommendedSerializerSettings()
           .UseMemoryStorage();
 });
+builder.Services.AddHangfireConsoleExtensions();
 var workerCount = builder.Configuration.GetSection("JobQueue:Concurrency:HangfireWorkerCount").Get<int>();
 if (workerCount > 0)
 {

--- a/src/DocflowAi.Net.Api/appsettings.json
+++ b/src/DocflowAi.Net.Api/appsettings.json
@@ -2,13 +2,15 @@
   "Serilog": {
     "Using": [
       "Serilog.Sinks.Console",
-      "Serilog.Sinks.File"
+      "Serilog.Sinks.File",
+      "Hangfire.Console.Extensions.Serilog"
     ],
     "MinimumLevel": "Information",
     "Enrich": [
       "FromLogContext",
       "WithMachineName",
-      "WithThreadId"
+      "WithThreadId",
+      "WithHangfireContext"
     ],
     "WriteTo": [
       {
@@ -19,6 +21,12 @@
         "Args": {
           "path": "logs/log-.txt",
           "rollingInterval": "Day"
+        }
+      },
+      {
+        "Name": "Hangfire",
+        "Args": {
+          "restrictedToMinimumLevel": "Information"
         }
       }
     ]

--- a/tests/DocflowAi.Net.Api.Tests/HangfireConsoleExtensionsTests.cs
+++ b/tests/DocflowAi.Net.Api.Tests/HangfireConsoleExtensionsTests.cs
@@ -1,0 +1,20 @@
+using DocflowAi.Net.Api.Tests.Fixtures;
+using FluentAssertions;
+using Hangfire.Console.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace DocflowAi.Net.Api.Tests;
+
+public class HangfireConsoleExtensionsTests : IClassFixture<TempDirFixture>
+{
+    private readonly TempDirFixture _fx;
+    public HangfireConsoleExtensionsTests(TempDirFixture fx) => _fx = fx;
+
+    [Fact]
+    public void Registers_Hangfire_Console_Services()
+    {
+        using var factory = new TestWebAppFactory(_fx.RootPath);
+        var manager = factory.Services.GetService<IJobManager>();
+        manager.Should().NotBeNull();
+    }
+}


### PR DESCRIPTION
## Summary
- capture logs in Hangfire dashboard via Hangfire.Console.Extensions
- configure Serilog to forward logs to Hangfire console
- verify Hangfire console services are registered

## Testing
- `rg -n -i 'pytest|:8000|sidecar|MarkitdownException|MARKITDOWN_URL|PY_MARKITDOWN_ENABLED'`
- `dotnet build -c Release`
- `dotnet test -c Release --no-build`
- `npm test -- --run` *(fails: 1 failed | 13 passed | 1 skipped)*
- `npm run build` *(fails: TemplateModal.tsx TS6133)*

------
https://chatgpt.com/codex/tasks/task_e_68a416a303d883258ec7283f76ce5a5b