### PR TITLE
feat(frontend): refine job list UI

### DIFF
--- a/frontend/src/pages/JobDetail.tsx
+++ b/frontend/src/pages/JobDetail.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useLocation, useParams } from 'react-router-dom';
 import { JobsService, type JobDetailResponse, OpenAPI, ApiError, ModelsService, TemplatesService } from '../generated';
-import { Descriptions, Progress, Button, Space, Modal, Tabs, Table } from 'antd';
+import { Descriptions, Button, Space, Modal, Tabs, Table } from 'antd';
 import ReloadOutlined from '@ant-design/icons/ReloadOutlined';
 import StopOutlined from '@ant-design/icons/StopOutlined';
 import FileSearchOutlined from '@ant-design/icons/FileSearchOutlined';
@@ -251,9 +251,6 @@ export default function JobDetail() {
       <Descriptions title={`Job ${job.id}`} bordered column={1} size="small">
         <Descriptions.Item label="Status">
           <JobStatusTag status={job.status!} derived={job.derivedStatus} />
-        </Descriptions.Item>
-        <Descriptions.Item label="Progress">
-          <Progress percent={job.progress || 0} />
         </Descriptions.Item>
         <Descriptions.Item label="Attempts">{job.attempts}</Descriptions.Item>
         <Descriptions.Item label="Model">

--- a/frontend/src/pages/JobsList.test.tsx
+++ b/frontend/src/pages/JobsList.test.tsx
@@ -15,7 +15,7 @@ vi.mock('antd', () => ({
       {dataSource.map((row: any) => (
         <div key={row.id}>
           <span>{row.id}</span>
-          {columns[6].render(null, row)}
+          {columns[7].render(null, row)}
         </div>
       ))}
       <button onClick={() => pagination.onChange(2, pagination.pageSize)}>2</button>
@@ -31,7 +31,6 @@ vi.mock('antd', () => ({
   ),
   Grid: { useBreakpoint: () => ({ md: true }) },
   Button: (props: any) => <button {...props} />,
-  Progress: () => <div />,
   Badge: () => <div />,
   Alert: () => null,
   Space: ({ children }: any) => <div>{children}</div>,
@@ -40,7 +39,14 @@ vi.mock('antd', () => ({
 test('pagination and cancel', async () => {
   const getSpy = vi
     .spyOn(JobsService, 'jobsList')
-    .mockResolvedValue({ items: [{ id: '1', status: 'Running', createdAt: '', updatedAt: '' } as any], page: 1, pageSize: 10, total: 20 });
+    .mockResolvedValue({
+      items: [
+        { id: '1', status: 'Running', createdAt: '', updatedAt: '', templateToken: 't', model: 'm' } as any,
+      ],
+      page: 1,
+      pageSize: 10,
+      total: 20,
+    });
   const cancelSpy = vi.spyOn(JobsService, 'jobsDelete').mockResolvedValue(undefined as any);
   render(
     <ApiErrorProvider>

--- a/frontend/src/pages/JobsList.tsx
+++ b/frontend/src/pages/JobsList.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Table, Space, Button, Progress, Badge, Alert, List, Grid } from 'antd';
+import { Table, Space, Button, Badge, Alert, List, Grid } from 'antd';
 import FileAddOutlined from '@ant-design/icons/FileAddOutlined';
 import EyeOutlined from '@ant-design/icons/EyeOutlined';
 import StopOutlined from '@ant-design/icons/StopOutlined';
@@ -88,7 +88,11 @@ export default function JobsList() {
     {
       title: 'ID',
       dataIndex: 'id',
-      render: (id: string) => <Link to={`/jobs/${id}`}>{id}</Link>,
+      render: (id: string) => (
+        <Link to={`/jobs/${id}`} title={id}>
+          {id.slice(0, 8)}
+        </Link>
+      ),
     },
     {
       title: 'Status',
@@ -106,10 +110,14 @@ export default function JobsList() {
       onFilter: (value, record) => record.status === value,
     },
     {
-      title: 'Progress',
-      dataIndex: 'progress',
-      render: (p?: number) => <Progress percent={p || 0} size="small" />,
-      responsive: ['md'],
+      title: 'Template',
+      dataIndex: 'templateToken',
+      responsive: ['lg'],
+    },
+    {
+      title: 'Model',
+      dataIndex: 'model',
+      responsive: ['xl'],
     },
     {
       title: 'Attempts',
@@ -189,7 +197,7 @@ export default function JobsList() {
         }}
       >
         <Link to="/jobs/new">
-          <Button aria-label="New Job" icon={<FileAddOutlined />} />
+          <Button type="primary" aria-label="New Job" icon={<FileAddOutlined />}>New job</Button>
         </Link>
       </div>
       {retry !== null && <Alert banner message={`Queue full. Retry in ${retry}s`} />}
@@ -203,10 +211,13 @@ export default function JobsList() {
             <List.Item key={record.id}>
               <Space direction="vertical" style={{ width: '100%' }}>
                 <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-                  <Link to={`/jobs/${record.id}`}>{record.id}</Link>
+                  <Link to={`/jobs/${record.id}`} title={record.id!}>
+                    {record.id!.slice(0, 8)}
+                  </Link>
                   <JobStatusTag status={record.status!} derived={record.derivedStatus} />
                 </div>
-                <Progress percent={record.progress || 0} size="small" />
+                <div>Template: {record.templateToken}</div>
+                <div>Model: {record.model}</div>
                 <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                   <span>{dayjs(record.updatedAt!).format('YYYY-MM-DD HH:mm')}</span>
                   <Space>


### PR DESCRIPTION
## Summary
- add primary "New job" button with label
- show compact IDs plus template and model tokens in job list
- remove progress bars from list and detail views

## Testing
- `rg -n -i 'pytest|:8000|sidecar|MarkitdownException|MARKITDOWN_URL|PY_MARKITDOWN_ENABLED' -g '!AGENTS.md'`
- `dotnet build -c Release`
- `dotnet test -c Release`
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4280ceaa08325b94a7db0d42e56eb