### PR TITLE
Seed jobs with model and template and fix job detail page

### DIFF
--- a/frontend/src/generated/models/JobSummary.ts
+++ b/frontend/src/generated/models/JobSummary.ts
@@ -1,0 +1,19 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * Summary information for a job.
+ */
+export type JobSummary = {
+    id?: string;
+    status?: string | null;
+    derivedStatus?: string | null;
+    progress?: number;
+    attempts?: number;
+    createdAt?: string;
+    updatedAt?: string;
+    model?: string | null;
+    templateToken?: string | null;
+};
+

--- a/frontend/src/generated/models/PagedJobsResponse.ts
+++ b/frontend/src/generated/models/PagedJobsResponse.ts
@@ -1,0 +1,15 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { JobSummary } from './JobSummary';
+/**
+ * Paged list of jobs.
+ */
+export type PagedJobsResponse = {
+    page?: number;
+    pageSize?: number;
+    total?: number;
+    items?: Array<JobSummary> | null;
+};
+

--- a/frontend/src/pages/JobDetail.test.tsx
+++ b/frontend/src/pages/JobDetail.test.tsx
@@ -1,0 +1,34 @@
+import { render, waitFor, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { test, vi } from 'vitest';
+import JobDetail from './JobDetail';
+import { JobsService, ApiError } from '../generated';
+import ApiErrorProvider from '../components/ApiErrorProvider';
+
+const { mockNotify } = vi.hoisted(() => ({ mockNotify: vi.fn() }));
+vi.mock('../components/notification', () => ({ notify: mockNotify, default: mockNotify }));
+
+vi.mock('antd', () => ({
+  Alert: ({ message }: any) => <div>{message}</div>,
+  notification: { error: vi.fn() },
+}));
+
+test('shows error when job is missing', async () => {
+  vi.spyOn(JobsService, 'jobsGetById').mockRejectedValueOnce(
+    new ApiError(
+      { method: 'GET', url: '/api/v1/jobs/1' } as any,
+      { url: '', status: 404, statusText: 'Not Found', body: {} },
+      'Not Found'
+    ),
+  );
+  render(
+    <ApiErrorProvider>
+      <MemoryRouter initialEntries={['/jobs/1']}>
+        <Routes>
+          <Route path="/jobs/:id" element={<JobDetail />} />
+        </Routes>
+      </MemoryRouter>
+    </ApiErrorProvider>,
+  );
+  await waitFor(() => screen.getByText('Job not found'));
+});

--- a/frontend/src/pages/JobDetail.tsx
+++ b/frontend/src/pages/JobDetail.tsx
@@ -140,6 +140,12 @@ export default function JobDetail() {
     fetchFields();
   }, [job]);
 
+  useEffect(() => {
+    if ((location.state as any)?.newJob) {
+      notify('success', 'Job created successfully.');
+    }
+  }, [location.state]);
+
   const handleCancel = async () => {
     if (!id) return;
     try {
@@ -251,12 +257,6 @@ export default function JobDetail() {
       ),
     },
   ];
-
-  useEffect(() => {
-    if ((location.state as any)?.newJob) {
-      notify('success', 'Job created successfully.');
-    }
-  }, [location.state]);
 
   return (
     <div>

--- a/frontend/src/pages/JobDetail.tsx
+++ b/frontend/src/pages/JobDetail.tsx
@@ -246,6 +246,8 @@ export default function JobDetail() {
     }
   }, [location.state]);
 
+  if (!job) return <Loader />;
+
   return (
     <div>
       <Descriptions title={`Job ${job.id}`} bordered column={1} size="small">

--- a/frontend/src/pages/JobDetail.tsx
+++ b/frontend/src/pages/JobDetail.tsx
@@ -36,8 +36,12 @@ export default function JobDetail() {
     try {
       const res = await JobsService.jobsGetById({ id });
       setJob(res);
-    } catch {
-      /* ignore */
+    } catch (e) {
+      if (e instanceof ApiError && e.status === 404) {
+        showError('Job not found');
+      } else if (e instanceof Error) {
+        showError(e.message);
+      }
     }
   };
 

--- a/frontend/src/pages/JobsList.tsx
+++ b/frontend/src/pages/JobsList.tsx
@@ -6,7 +6,7 @@ import StopOutlined from '@ant-design/icons/StopOutlined';
 import FileTextOutlined from '@ant-design/icons/FileTextOutlined';
 import FileExclamationOutlined from '@ant-design/icons/FileExclamationOutlined';
 import type { ColumnsType, TablePaginationConfig } from 'antd/es/table';
-import { JobsService, type JobDetailResponse, ApiError } from '../generated';
+import { JobsService, type JobSummary, type JobDetailResponse, ApiError } from '../generated';
 import JobStatusTag from '../components/JobStatusTag';
 import notify from '../components/notification';
 import { Link } from 'react-router-dom';
@@ -17,7 +17,8 @@ import { useApiError } from '../components/ApiErrorProvider';
 const terminal = ['Succeeded', 'Failed', 'Cancelled'];
 
 export default function JobsList() {
-  const [jobs, setJobs] = useState<JobDetailResponse[]>([]);
+  type JobListItem = JobSummary & { paths?: JobDetailResponse['paths'] };
+  const [jobs, setJobs] = useState<JobListItem[]>([]);
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState<number>(() => Number(localStorage.getItem('pageSize') || 10));
   const [total, setTotal] = useState(0);
@@ -31,7 +32,7 @@ export default function JobsList() {
     setLoading(true);
     try {
       const res = await JobsService.jobsList({ page, pageSize });
-      const items = (res.items || []) as JobDetailResponse[];
+      const items = (res.items || []) as JobListItem[];
       setJobs(items);
       setTotal(res.total || 0);
       if (items.some((j) => !terminal.includes(j.status!))) {
@@ -84,7 +85,7 @@ export default function JobsList() {
     }
   };
 
-  const columns: ColumnsType<JobDetailResponse> = [
+  const columns: ColumnsType<JobListItem> = [
     {
       title: 'ID',
       dataIndex: 'id',
@@ -97,7 +98,7 @@ export default function JobsList() {
     {
       title: 'Status',
       dataIndex: 'status',
-      render: (_: string, record: JobDetailResponse) => (
+      render: (_: string, record: JobListItem) => (
         <JobStatusTag status={record.status!} derived={record.derivedStatus} />
       ),
       filters: [
@@ -139,7 +140,7 @@ export default function JobsList() {
     },
     {
       title: 'Actions',
-      render: (_: any, record: JobDetailResponse) => (
+      render: (_: any, record: JobListItem) => (
         <Space>
           <Link to={`/jobs/${record.id}`} title="View job">
             <Button icon={<EyeOutlined />} aria-label="View job" title="View job" />

--- a/frontend/swagger/v1/swagger.json
+++ b/frontend/swagger/v1/swagger.json
@@ -1181,6 +1181,10 @@
             "type": "integer",
             "format": "int32"
           },
+          "attempts": {
+            "type": "integer",
+            "format": "int32"
+          },
           "createdAt": {
             "type": "string",
             "format": "date-time"
@@ -1188,6 +1192,14 @@
           "updatedAt": {
             "type": "string",
             "format": "date-time"
+          },
+          "model": {
+            "type": "string",
+            "nullable": true
+          },
+          "templateToken": {
+            "type": "string",
+            "nullable": true
           }
         },
         "additionalProperties": false,

--- a/src/DocflowAi.Net.Api/Contracts/JobSummary.cs
+++ b/src/DocflowAi.Net.Api/Contracts/JobSummary.cs
@@ -3,7 +3,16 @@ using DocflowAi.Net.Api.JobQueue.Models;
 namespace DocflowAi.Net.Api.Contracts;
 
 /// <summary>Summary information for a job.</summary>
-public record JobSummary(Guid Id, string Status, string DerivedStatus, int Progress, DateTimeOffset CreatedAt, DateTimeOffset UpdatedAt);
+public record JobSummary(
+    Guid Id,
+    string Status,
+    string DerivedStatus,
+    int Progress,
+    int Attempts,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset UpdatedAt,
+    string Model,
+    string TemplateToken);
 
 /// <summary>Paged list of jobs.</summary>
 public record PagedJobsResponse(int Page, int PageSize, int Total, IReadOnlyList<JobSummary> Items);

--- a/src/DocflowAi.Net.Api/JobQueue/Data/DefaultJobSeeder.cs
+++ b/src/DocflowAi.Net.Api/JobQueue/Data/DefaultJobSeeder.cs
@@ -37,6 +37,8 @@ public static class DefaultJobSeeder
             if (datasetRoot != null)
             {
                 var now = DateTimeOffset.UtcNow;
+                var modelName = db.Models.Select(m => m.Name).FirstOrDefault() ?? "model";
+                var templateToken = db.Templates.Select(t => t.Token).FirstOrDefault() ?? "template";
 
                 var okId = Guid.Parse("11111111-1111-1111-1111-111111111111");
                 var okDir = Path.Combine(cfg.DataRoot, okId.ToString());
@@ -52,8 +54,8 @@ public static class DefaultJobSeeder
                     CreatedAt = now,
                     UpdatedAt = now,
                     Metrics = new JobDocument.MetricsInfo { StartedAt = now, EndedAt = now, DurationMs = 0 },
-                    Model = "model",
-                    TemplateToken = "template",
+                    Model = modelName,
+                    TemplateToken = templateToken,
                     Paths = new JobDocument.PathInfo
                     {
                         Dir = okDir,
@@ -78,8 +80,8 @@ public static class DefaultJobSeeder
                     UpdatedAt = now,
                     ErrorMessage = "Processing failed",
                     Metrics = new JobDocument.MetricsInfo(),
-                    Model = "model",
-                    TemplateToken = "template",
+                    Model = modelName,
+                    TemplateToken = templateToken,
                     Paths = new JobDocument.PathInfo
                     {
                         Dir = errDir,

--- a/src/DocflowAi.Net.Api/JobQueue/Endpoints/JobEndpoints.cs
+++ b/src/DocflowAi.Net.Api/JobQueue/Endpoints/JobEndpoints.cs
@@ -43,7 +43,17 @@ public static class JobEndpoints
                 p,
                 ps,
                 total,
-                items.Select(i => new JobSummary(i.Id, i.Status, MapDerivedStatus(i.Status), i.Progress, i.CreatedAt, i.UpdatedAt)).ToList()
+                items.Select(i => new JobSummary(
+                    i.Id,
+                    i.Status,
+                    MapDerivedStatus(i.Status),
+                    i.Progress,
+                    i.Attempts,
+                    i.CreatedAt,
+                    i.UpdatedAt,
+                    i.Model,
+                    i.TemplateToken
+                )).ToList()
             );
             return Results.Ok(response);
         })

--- a/src/DocflowAi.Net.Api/Program.cs
+++ b/src/DocflowAi.Net.Api/Program.cs
@@ -205,6 +205,12 @@ builder.Services.AddHttpClient<ILlmModelService, LlmModelService>();
 builder.Services.AddHealthChecks()
     .AddCheck<JobQueueReadyHealthCheck>("jobqueue", tags: new[] { "ready" });
 
+var port = Environment.GetEnvironmentVariable("PORT");
+if (!string.IsNullOrEmpty(port))
+{
+    builder.WebHost.UseUrls($"http://0.0.0.0:{port}");
+}
+
 var app = builder.Build();
 DefaultModelSeeder.Build(app);
 DefaultTemplateSeeder.Build(app);

--- a/src/DocflowAi.Net.Api/Program.cs
+++ b/src/DocflowAi.Net.Api/Program.cs
@@ -206,9 +206,9 @@ builder.Services.AddHealthChecks()
     .AddCheck<JobQueueReadyHealthCheck>("jobqueue", tags: new[] { "ready" });
 
 var app = builder.Build();
-DefaultJobSeeder.Build(app);
 DefaultModelSeeder.Build(app);
 DefaultTemplateSeeder.Build(app);
+DefaultJobSeeder.Build(app);
 
 app.UseSerilogRequestLogging(opts =>
 {

--- a/tests/DocflowAi.Net.Api.Tests/DefaultJobSeederTests.cs
+++ b/tests/DocflowAi.Net.Api.Tests/DefaultJobSeederTests.cs
@@ -32,6 +32,10 @@ public class DefaultJobSeederTests : IClassFixture<TempDirFixture>
         resp!.total.Should().Be(2);
         resp.items.Select(j => j.id).Should().Contain(Guid.Parse("11111111-1111-1111-1111-111111111111"));
         resp.items.Select(j => j.id).Should().Contain(Guid.Parse("22222222-2222-2222-2222-222222222222"));
+
+        var ok = await client.GetFromJsonAsync<JsonElement>("/api/v1/jobs/11111111-1111-1111-1111-111111111111");
+        ok.GetProperty("model").GetString().Should().NotBeNullOrWhiteSpace();
+        ok.GetProperty("templateToken").GetString().Should().NotBeNullOrWhiteSpace();
     }
 
     [Fact]

--- a/tests/DocflowAi.Net.Api.Tests/JobsListEndpointTests.cs
+++ b/tests/DocflowAi.Net.Api.Tests/JobsListEndpointTests.cs
@@ -107,6 +107,6 @@ public class JobsListEndpointTests : IClassFixture<TempDirFixture>
     }
 
     private record JobListResponse(int page, int pageSize, int total, List<JobItem> items);
-    private record JobItem(Guid id, string status, string derivedStatus, int progress, DateTimeOffset createdAt, DateTimeOffset updatedAt);
+    private record JobItem(Guid id, string status, string derivedStatus, int progress, int attempts, DateTimeOffset createdAt, DateTimeOffset updatedAt, string model, string templateToken);
     private record ErrorResponse(string error, string? message);
 }

--- a/tests/DocflowAi.Net.Api.Tests/ModelServiceTests.cs
+++ b/tests/DocflowAi.Net.Api.Tests/ModelServiceTests.cs
@@ -208,4 +208,21 @@ public class ModelServiceTests
         service.Delete(model.Id);
         db.Models.Should().BeEmpty();
     }
+
+    [Fact]
+    public void DeleteModel_WhenMultipleExist_RemovesOnlyTarget()
+    {
+        var options = new DbContextOptionsBuilder<JobDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        using var db = new JobDbContext(options);
+        var client = new FakeBackgroundJobClient();
+        var service = CreateService(db, Path.GetTempPath(), client);
+        var m1 = service.Create(new CreateModelRequest { Name = "m1", Type = "local", HfRepo = "r1", ModelFile = "f1" });
+        var m2 = service.Create(new CreateModelRequest { Name = "m2", Type = "local", HfRepo = "r2", ModelFile = "f2" });
+
+        service.Delete(m1.Id);
+
+        db.Models.Should().ContainSingle(m => m.Id == m2.Id);
+    }
 }


### PR DESCRIPTION
## Summary
- use existing model and template tokens when seeding default jobs
- run model and template seeders before job seeder
- show loader on job detail until data is loaded
- cover seeded job metadata in tests

## Testing
- `rg -n -i 'pytest|:8000|sidecar|MarkitdownException|MARKITDOWN_URL|PY_MARKITDOWN_ENABLED' -g '!AGENTS.md'`
- `dotnet build -c Release`
- `dotnet test tests/DocflowAi.Net.Api.Tests/DocflowAi.Net.Api.Tests.csproj -c Release`
- `dotnet test tests/DocflowAi.Net.BBoxResolver.Tests/DocflowAi.Net.BBoxResolver.Tests.csproj -c Release`
- `dotnet test tests/DocflowAi.Net.Tests.Unit/DocflowAi.Net.Tests.Unit.csproj -c Release`
- `dotnet test tests/XFundEvalRunner.Tests/XFundEvalRunner.Tests.csproj -c Release`
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a42d32ee048325a569d9b86c7ff888