### PR TITLE
Store template fields as array

### DIFF
--- a/frontend/src/components/FieldsEditor.tsx
+++ b/frontend/src/components/FieldsEditor.tsx
@@ -9,13 +9,13 @@ export interface FieldItem {
 }
 
 export function fieldsToJson(fields: FieldItem[]): string {
-  return JSON.stringify({ fields }, null, 2);
+  return JSON.stringify(fields, null, 2);
 }
 
 export function jsonToFields(json: string): FieldItem[] {
   const parsed = JSON.parse(json);
-  if (!parsed || !Array.isArray(parsed.fields)) return [];
-  return parsed.fields as FieldItem[];
+  if (!Array.isArray(parsed)) return [];
+  return parsed as FieldItem[];
 }
 
 interface Props {

--- a/frontend/src/components/TemplateFieldsEditor.test.tsx
+++ b/frontend/src/components/TemplateFieldsEditor.test.tsx
@@ -63,7 +63,7 @@ test('mode switch preserves data', () => {
   const textarea = screen.getByRole('textbox');
   expect(textarea.value).toContain('"name": "id"');
   fireEvent.change(textarea, {
-    target: { value: '{"fields":[{"name":"foo","type":"number"}]}' },
+    target: { value: '[{"name":"foo","type":"number"}]' },
   });
   fireEvent.click(screen.getByText('Visual'));
   expect(screen.getByDisplayValue('foo')).toBeTruthy();

--- a/frontend/src/components/TemplateModal.test.tsx
+++ b/frontend/src/components/TemplateModal.test.tsx
@@ -85,9 +85,9 @@ test('create flow', async () => {
   expect(createSpy).toHaveBeenCalled();
   await waitFor(() => expect(onClose).toHaveBeenCalledWith(true));
   expect(notify).toHaveBeenCalledWith('success', 'Template created successfully.');
-  expect(createSpy.mock.calls[0][0].requestBody.fieldsJson).toEqual({
-    fields: [{ name: 'k', type: 'string' }],
-  });
+  expect(createSpy.mock.calls[0][0].requestBody.fieldsJson).toEqual([
+    { name: 'k', type: 'string' },
+  ]);
 });
 
 test('update flow', async () => {
@@ -95,7 +95,7 @@ test('update flow', async () => {
     id: '1',
     name: 'a',
     token: 'a',
-    fieldsJson: {},
+    fieldsJson: [],
   } as any);
   const updateSpy = vi.spyOn(TemplatesService, 'templatesUpdate').mockResolvedValue({} as any);
   const onClose = vi.fn();
@@ -113,7 +113,7 @@ test('does not show timestamps on edit', async () => {
     id: '1',
     name: 'a',
     token: 'a',
-    fieldsJson: {},
+    fieldsJson: [],
     createdAt: '2024-01-01T00:00:00Z',
     updatedAt: '2024-01-02T00:00:00Z',
   } as any);

--- a/frontend/src/components/TemplateModal.tsx
+++ b/frontend/src/components/TemplateModal.tsx
@@ -32,7 +32,7 @@ export default function TemplateModal({ open, templateId, onClose }: Props) {
         setToken(t.token || '');
         setPrompt(t.promptMarkdown || '');
         try {
-          setFields(jsonToFields(JSON.stringify(t.fieldsJson ?? { fields: [] })));
+          setFields(jsonToFields(JSON.stringify(t.fieldsJson ?? [])));
         } catch {
           setFields([]);
         }

--- a/src/DocflowAi.Net.Api/Templates/Data/DefaultTemplateSeeder.cs
+++ b/src/DocflowAi.Net.Api/Templates/Data/DefaultTemplateSeeder.cs
@@ -41,12 +41,12 @@ public static class DefaultTemplateSeeder
                     prompt = File.ReadAllText(promptPath);
             }
 
-            var fields = new
+            var fields = new[]
             {
-                company_name = "",
-                document_type = "",
-                invoice_number = "",
-                invoice_date = ""
+                new { Key = "company_name", Description = "", Type = "string", Required = false },
+                new { Key = "document_type", Description = "", Type = "string", Required = false },
+                new { Key = "invoice_number", Description = "", Type = "string", Required = false },
+                new { Key = "invoice_date", Description = "", Type = "string", Required = false }
             };
 
             var tpl = new TemplateDocument

--- a/src/DocflowAi.Net.Api/Templates/Services/TemplateService.cs
+++ b/src/DocflowAi.Net.Api/Templates/Services/TemplateService.cs
@@ -33,8 +33,8 @@ public class TemplateService : ITemplateService
     {
         ValidateName(request.Name, null);
         ValidateToken(request.Token, null);
-        if (request.FieldsJson.ValueKind != JsonValueKind.Object)
-            throw new ArgumentException("fieldsJson must be an object");
+        if (request.FieldsJson.ValueKind != JsonValueKind.Array)
+            throw new ArgumentException("fieldsJson must be an array");
 
         var doc = new TemplateDocument
         {
@@ -66,8 +66,8 @@ public class TemplateService : ITemplateService
             existing.PromptMarkdown = request.PromptMarkdown;
         if (request.FieldsJson.HasValue)
         {
-            if (request.FieldsJson.Value.ValueKind != JsonValueKind.Object)
-                throw new ArgumentException("fieldsJson must be an object");
+            if (request.FieldsJson.Value.ValueKind != JsonValueKind.Array)
+                throw new ArgumentException("fieldsJson must be an array");
             existing.FieldsJson = request.FieldsJson.Value.GetRawText();
         }
         _repo.Update(existing);

--- a/tests/DocflowAi.Net.Api.Tests/DefaultTemplateSeederTests.cs
+++ b/tests/DocflowAi.Net.Api.Tests/DefaultTemplateSeederTests.cs
@@ -28,7 +28,7 @@ public class DefaultTemplateSeederTests : IClassFixture<TempDirFixture>
         var tplId = list.Items.Single(t => t.Token == "template").Id;
         var tpl = await client.GetFromJsonAsync<TemplateDto>($"/api/templates/{tplId}");
         tpl!.PromptMarkdown.Should().NotBeNullOrWhiteSpace();
-        tpl.FieldsJson.TryGetProperty("invoice_number", out _).Should().BeTrue();
+        tpl.FieldsJson.EnumerateArray().Any(e => e.GetProperty("Key").GetString() == "invoice_number").Should().BeTrue();
         var bpId = list.Items.Single(t => t.Token == "busta-paga").Id;
         var bp = await client.GetFromJsonAsync<TemplateDto>($"/api/templates/{bpId}");
         bp!.PromptMarkdown.Should().NotBeNullOrWhiteSpace();

--- a/tests/DocflowAi.Net.Api.Tests/TemplateServiceTests.cs
+++ b/tests/DocflowAi.Net.Api.Tests/TemplateServiceTests.cs
@@ -30,7 +30,7 @@ public class TemplateServiceTests
             "t1",
             "tok1",
             null,
-            JsonDocument.Parse("{\"a\":1}").RootElement));
+            JsonDocument.Parse("[]").RootElement));
         dto.CreatedAt.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(5));
         dto.UpdatedAt.Should().BeCloseTo(dto.CreatedAt, TimeSpan.FromSeconds(5));
     }
@@ -43,8 +43,8 @@ public class TemplateServiceTests
             .Options;
         using var db = new JobDbContext(options);
         var service = CreateService(db);
-        service.Create(new CreateTemplateRequest("t1", "tok1", null, JsonDocument.Parse("{}" ).RootElement));
-        Action act = () => service.Create(new CreateTemplateRequest("t1", "tok2", null, JsonDocument.Parse("{}" ).RootElement));
+        service.Create(new CreateTemplateRequest("t1", "tok1", null, JsonDocument.Parse("[]" ).RootElement));
+        Action act = () => service.Create(new CreateTemplateRequest("t1", "tok2", null, JsonDocument.Parse("[]" ).RootElement));
         act.Should().Throw<InvalidOperationException>();
     }
 
@@ -56,20 +56,20 @@ public class TemplateServiceTests
             .Options;
         using var db = new JobDbContext(options);
         var service = CreateService(db);
-        Action act = () => service.Create(new CreateTemplateRequest("t1", "bad token", null, JsonDocument.Parse("{}" ).RootElement));
+        Action act = () => service.Create(new CreateTemplateRequest("t1", "bad token", null, JsonDocument.Parse("[]" ).RootElement));
         act.Should().Throw<ArgumentException>();
     }
 
     [Fact]
-    public void FieldsJsonMustBeObject()
+    public void FieldsJsonMustBeArray()
     {
         var options = new DbContextOptionsBuilder<JobDbContext>()
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
             .Options;
         using var db = new JobDbContext(options);
         var service = CreateService(db);
-        var arr = JsonDocument.Parse("[]").RootElement;
-        Action act = () => service.Create(new CreateTemplateRequest("t1", "tok1", null, arr));
+        var obj = JsonDocument.Parse("{}").RootElement;
+        Action act = () => service.Create(new CreateTemplateRequest("t1", "tok1", null, obj));
         act.Should().Throw<ArgumentException>();
     }
 
@@ -81,11 +81,11 @@ public class TemplateServiceTests
             .Options;
         using var db = new JobDbContext(options);
         var service = CreateService(db);
-        var tpl = service.Create(new CreateTemplateRequest("t1", "tok1", null, JsonDocument.Parse("{}" ).RootElement));
-        var updated = service.Update(tpl.Id, new UpdateTemplateRequest("t2", "tok2", "p", JsonDocument.Parse("{\"b\":2}").RootElement));
+        var tpl = service.Create(new CreateTemplateRequest("t1", "tok1", null, JsonDocument.Parse("[]" ).RootElement));
+        var updated = service.Update(tpl.Id, new UpdateTemplateRequest("t2", "tok2", "p", JsonDocument.Parse("[{\"b\":2}]").RootElement));
         updated.Name.Should().Be("t2");
         updated.Token.Should().Be("tok2");
-        updated.FieldsJson.GetProperty("b").GetInt32().Should().Be(2);
+        updated.FieldsJson[0].GetProperty("b").GetInt32().Should().Be(2);
         updated.UpdatedAt.Should().BeAfter(updated.CreatedAt);
     }
 
@@ -97,11 +97,11 @@ public class TemplateServiceTests
             .Options;
         using var db = new JobDbContext(options);
         var service = CreateService(db);
-        service.Create(new CreateTemplateRequest("t1", "tok1", null, JsonDocument.Parse("{}" ).RootElement));
+        service.Create(new CreateTemplateRequest("t1", "tok1", null, JsonDocument.Parse("[]" ).RootElement));
         System.Threading.Thread.Sleep(10);
-        service.Create(new CreateTemplateRequest("t2", "tok2", null, JsonDocument.Parse("{}" ).RootElement));
+        service.Create(new CreateTemplateRequest("t2", "tok2", null, JsonDocument.Parse("[]" ).RootElement));
         System.Threading.Thread.Sleep(10);
-        service.Create(new CreateTemplateRequest("t3", "tok3", null, JsonDocument.Parse("{}" ).RootElement));
+        service.Create(new CreateTemplateRequest("t3", "tok3", null, JsonDocument.Parse("[]" ).RootElement));
         var page1 = service.GetPaged(null, 1, 2, null);
         page1.Total.Should().Be(3);
         page1.Items.Should().HaveCount(2);
@@ -119,7 +119,7 @@ public class TemplateServiceTests
             .Options;
         using var db = new JobDbContext(options);
         var service = CreateService(db);
-        var tpl = service.Create(new CreateTemplateRequest("t1", "tok1", null, JsonDocument.Parse("{}" ).RootElement));
+        var tpl = service.Create(new CreateTemplateRequest("t1", "tok1", null, JsonDocument.Parse("[]" ).RootElement));
         service.Delete(tpl.Id);
         service.GetById(tpl.Id).Should().BeNull();
     }
@@ -132,8 +132,8 @@ public class TemplateServiceTests
             .Options;
         using var db = new JobDbContext(options);
         var service = CreateService(db);
-        service.Create(new CreateTemplateRequest("t1", "tok1", null, JsonDocument.Parse("{}" ).RootElement));
-        Action act = () => service.Create(new CreateTemplateRequest("t2", "tok1", null, JsonDocument.Parse("{}" ).RootElement));
+        service.Create(new CreateTemplateRequest("t1", "tok1", null, JsonDocument.Parse("[]" ).RootElement));
+        Action act = () => service.Create(new CreateTemplateRequest("t2", "tok1", null, JsonDocument.Parse("[]" ).RootElement));
         act.Should().Throw<InvalidOperationException>();
     }
 
@@ -145,7 +145,7 @@ public class TemplateServiceTests
             .Options;
         using var db = new JobDbContext(options);
         var service = CreateService(db);
-        Action act = () => service.Create(new CreateTemplateRequest("", "tok1", null, JsonDocument.Parse("{}" ).RootElement));
+        Action act = () => service.Create(new CreateTemplateRequest("", "tok1", null, JsonDocument.Parse("[]" ).RootElement));
         act.Should().Throw<ArgumentException>();
     }
 
@@ -168,8 +168,8 @@ public class TemplateServiceTests
             .Options;
         using var db = new JobDbContext(options);
         var service = CreateService(db);
-        var t1 = service.Create(new CreateTemplateRequest("t1", "tok1", null, JsonDocument.Parse("{}" ).RootElement));
-        var t2 = service.Create(new CreateTemplateRequest("t2", "tok2", null, JsonDocument.Parse("{}" ).RootElement));
+        var t1 = service.Create(new CreateTemplateRequest("t1", "tok1", null, JsonDocument.Parse("[]" ).RootElement));
+        var t2 = service.Create(new CreateTemplateRequest("t2", "tok2", null, JsonDocument.Parse("[]" ).RootElement));
         Action act = () => service.Update(t2.Id, new UpdateTemplateRequest("t1", null, null, null));
         act.Should().Throw<InvalidOperationException>();
     }
@@ -182,8 +182,8 @@ public class TemplateServiceTests
             .Options;
         using var db = new JobDbContext(options);
         var service = CreateService(db);
-        var t1 = service.Create(new CreateTemplateRequest("t1", "tok1", null, JsonDocument.Parse("{}" ).RootElement));
-        var t2 = service.Create(new CreateTemplateRequest("t2", "tok2", null, JsonDocument.Parse("{}" ).RootElement));
+        var t1 = service.Create(new CreateTemplateRequest("t1", "tok1", null, JsonDocument.Parse("[]" ).RootElement));
+        var t2 = service.Create(new CreateTemplateRequest("t2", "tok2", null, JsonDocument.Parse("[]" ).RootElement));
         Action act = () => service.Update(t2.Id, new UpdateTemplateRequest(null, "tok1", null, null));
         act.Should().Throw<InvalidOperationException>();
     }
@@ -196,7 +196,7 @@ public class TemplateServiceTests
             .Options;
         using var db = new JobDbContext(options);
         var service = CreateService(db);
-        var t = service.Create(new CreateTemplateRequest("t1", "tok1", null, JsonDocument.Parse("{}" ).RootElement));
+        var t = service.Create(new CreateTemplateRequest("t1", "tok1", null, JsonDocument.Parse("[]" ).RootElement));
         Action act = () => service.Update(t.Id, new UpdateTemplateRequest(null, "bad token", null, null));
         act.Should().Throw<ArgumentException>();
     }
@@ -209,9 +209,9 @@ public class TemplateServiceTests
             .Options;
         using var db = new JobDbContext(options);
         var service = CreateService(db);
-        var t = service.Create(new CreateTemplateRequest("t1", "tok1", null, JsonDocument.Parse("{}" ).RootElement));
-        var arr = JsonDocument.Parse("[]").RootElement;
-        Action act = () => service.Update(t.Id, new UpdateTemplateRequest(null, null, null, arr));
+        var t = service.Create(new CreateTemplateRequest("t1", "tok1", null, JsonDocument.Parse("[]" ).RootElement));
+        var obj = JsonDocument.Parse("{}").RootElement;
+        Action act = () => service.Update(t.Id, new UpdateTemplateRequest(null, null, null, obj));
         act.Should().Throw<ArgumentException>();
     }
 
@@ -247,7 +247,7 @@ public class TemplateServiceTests
             .Options;
         using var db = new JobDbContext(options);
         var service = CreateService(db);
-        service.Create(new CreateTemplateRequest("t1", "tok1", null, JsonDocument.Parse("{}" ).RootElement));
+        service.Create(new CreateTemplateRequest("t1", "tok1", null, JsonDocument.Parse("[]" ).RootElement));
         var r1 = service.GetPaged(null, 0, 0, null);
         r1.Page.Should().Be(1);
         r1.PageSize.Should().Be(20);


### PR DESCRIPTION
## Summary
- store template `fieldsJson` as a bare array instead of nested object
- adjust default template seeding and validation to array format
- update frontend field editors and tests for array JSON

## Testing
- `rg -n -i 'pytest|:8000|sidecar|MarkitdownException|MARKITDOWN_URL|PY_MARKITDOWN_ENABLED'`
- `dotnet build -c Release`
- `dotnet test -c Release`
- `npm test -- --run`
- `npm run build`
- `dotnet run --project tools/DatasetCli -- --dataset dataset --output llm_output.json --template template`

------
https://chatgpt.com/codex/tasks/task_e_68a490316f10832591c388619f817ddf