### PR TITLE
feat: apply custom notification color palette

### DIFF
--- a/frontend/src/components/notification.tsx
+++ b/frontend/src/components/notification.tsx
@@ -14,10 +14,7 @@ let apiRef: ReturnType<typeof notification.useNotification>[0] | undefined;
 let tokenRef:
   | Pick<
       ReturnType<typeof theme.useToken>['token'],
-      | 'colorSuccess'
-      | 'colorError'
-      | 'colorWarning'
-      | 'fontWeightStrong'
+      'colorWarning' | 'fontWeightStrong'
     >
   | undefined;
 
@@ -45,17 +42,34 @@ export function notify(
 ): void {
   const backgroundColor =
     type === 'success'
-      ? tokenRef?.colorSuccess
+      ? 'var(--success-bg)'
       : type === 'error'
-        ? tokenRef?.colorError
+        ? 'var(--error-bg)'
         : tokenRef?.colorWarning;
-  const color = '#fff';
+  const color =
+    type === 'success'
+      ? 'var(--success-text)'
+      : type === 'error'
+        ? 'var(--error-text)'
+        : '#fff';
+  const borderColor =
+    type === 'success'
+      ? 'var(--success-border)'
+      : type === 'error'
+        ? 'var(--error-border)'
+        : undefined;
+  const iconColor =
+    type === 'success'
+      ? 'var(--success-icon)'
+      : type === 'error'
+        ? 'var(--error-icon)'
+        : '#fff';
   const icon =
     type === 'success'
-      ? <CheckCircleFilled style={{ color }} />
+      ? <CheckCircleFilled style={{ color: iconColor }} />
       : type === 'error'
-        ? <CloseCircleFilled style={{ color }} />
-        : <ExclamationCircleFilled style={{ color }} />;
+        ? <CloseCircleFilled style={{ color: iconColor }} />
+        : <ExclamationCircleFilled style={{ color: iconColor }} />;
   apiRef?.open({
     type,
     message,
@@ -66,9 +80,10 @@ export function notify(
       backgroundColor,
       color,
       fontWeight: tokenRef?.fontWeightStrong ?? 'bold',
+      border: borderColor ? `1px solid ${borderColor}` : undefined,
     },
     icon,
-    closeIcon: <CloseOutlined style={{ color }} />,
+    closeIcon: <CloseOutlined />,
   });
 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,3 +1,21 @@
+:root {
+  --error-text: #9e3d3b;
+  --error-bg: #fcefee;
+  --error-border: #e3afac;
+  --error-fill: #9e3d3b;
+  --error-icon: #9e3d3b;
+  --error-close: #9e3d3b;
+  --error-close-hover: #863332;
+
+  --success-text: #67974b;
+  --success-bg: #f6feef;
+  --success-border: #c5e0ab;
+  --success-fill: #67974b;
+  --success-icon: #67974b;
+  --success-close: #67974b;
+  --success-close-hover: #57803f;
+}
+
 body {
   margin: 0;
   background: #fff;
@@ -28,4 +46,32 @@ body {
   height: 100%;
   overflow-y: auto;
   padding: 0;
+}
+
+.ant-notification-notice-success .ant-notification-notice-progress-bg,
+.ant-notification-notice-success .ant-notification-notice-progress::-moz-progress-bar,
+.ant-notification-notice-success .ant-notification-notice-progress::-webkit-progress-value {
+  background: var(--success-fill);
+}
+
+.ant-notification-notice-error .ant-notification-notice-progress-bg,
+.ant-notification-notice-error .ant-notification-notice-progress::-moz-progress-bar,
+.ant-notification-notice-error .ant-notification-notice-progress::-webkit-progress-value {
+  background: var(--error-fill);
+}
+
+.ant-notification-notice-success .ant-notification-notice-close {
+  color: var(--success-close);
+}
+
+.ant-notification-notice-error .ant-notification-notice-close {
+  color: var(--error-close);
+}
+
+.ant-notification-notice-success .ant-notification-notice-close:hover {
+  color: var(--success-close-hover);
+}
+
+.ant-notification-notice-error .ant-notification-notice-close:hover {
+  color: var(--error-close-hover);
 }


### PR DESCRIPTION
## Summary
- use custom success/error colors for notifications
- expose palette via CSS variables

## Testing
- `dotnet build -c Release`
- `dotnet test -c Release tests/DocflowAi.Net.Api.Tests`
- `dotnet test -c Release tests/DocflowAi.Net.BBoxResolver.Tests`
- `dotnet test -c Release tests/DocflowAi.Net.Tests.Unit`
- `dotnet test -c Release tests/XFundEvalRunner.Tests`
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4950d56248325bff926c3342d6739