### PR TITLE
feat: add markdown converter page and secure endpoint

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ const HealthPage = lazy(() => import('./pages/HealthPage'));
 const ModelManagerPage = lazy(() => import('./pages/ModelManagerPage'));
 const ModelsPage = lazy(() => import('./pages/ModelsPage'));
 const TemplatesList = lazy(() => import('./pages/TemplatesList'));
+const MarkdownPage = lazy(() => import('./pages/MarkdownPage'));
 import { OpenAPI } from './generated';
 
 function App() {
@@ -42,6 +43,7 @@ function App() {
             <Route path="model" element={<ModelManagerPage />} />
             <Route path="models" element={<ModelsPage />} />
             <Route path="templates" element={<TemplatesList />} />
+            <Route path="markdown" element={<MarkdownPage />} />
             <Route path="*" element={<Navigate to="/jobs" />} />
           </Route>
         </Routes>

--- a/frontend/src/Shell.tsx
+++ b/frontend/src/Shell.tsx
@@ -11,6 +11,7 @@ import LinkOutlined from '@ant-design/icons/LinkOutlined';
 import ExperimentOutlined from '@ant-design/icons/ExperimentOutlined';
 import MenuOutlined from '@ant-design/icons/MenuOutlined';
 import RobotOutlined from '@ant-design/icons/RobotOutlined';
+import FileMarkdownOutlined from '@ant-design/icons/FileMarkdownOutlined';
 import { useState } from 'react';
 import { openHangfire } from './hangfire';
 
@@ -38,6 +39,7 @@ export default function Shell() {
     { key: '/jobs/new', icon: <FileAddOutlined />, label: 'New Job' },
     { key: '/models', icon: <ExperimentOutlined />, label: 'Models' },
     { key: '/templates', icon: <AppstoreOutlined />, label: 'Templates' },
+    { key: '/markdown', icon: <FileMarkdownOutlined />, label: 'Markdown' },
     { key: '/health', icon: <HeartOutlined />, label: 'Health' },
     {
       key: 'hangfire',

--- a/frontend/src/pages/MarkdownPage.test.tsx
+++ b/frontend/src/pages/MarkdownPage.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { expect, test, vi } from 'vitest';
+import MarkdownPage, { convertFile } from './MarkdownPage';
+import { ApiError } from '../generated';
+
+vi.mock('../generated/core/request', () => ({
+  request: vi.fn(),
+}));
+
+vi.mock('../components/ApiErrorProvider', () => ({
+  useApiError: () => ({ showError: vi.fn() }),
+}));
+
+import { request as __request } from '../generated/core/request';
+
+test('convertFile', async () => {
+  const file = new File(['a'], 'a.png');
+  (__request as any).mockResolvedValueOnce({ markdown: 'ok', pages: [], boxes: [] });
+  const res = await convertFile(file);
+  expect(res).toMatchObject({ markdown: 'ok' });
+  (__request as any).mockRejectedValueOnce(
+    new ApiError({ method: 'POST', url: '/markdown' } as any, { url: '', status: 500, statusText: 'err', body: {} }, 'err')
+  );
+  await expect(convertFile(file)).rejects.toBeInstanceOf(ApiError);
+});
+
+test('renders markdown and json', async () => {
+  (__request as any).mockResolvedValueOnce({ markdown: 'hello', pages: [], boxes: [] });
+  render(<MarkdownPage />);
+  const file = new File(['a'], 'a.png');
+  const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+  fireEvent.change(input, { target: { files: [file] } });
+  fireEvent.click(screen.getByRole('button', { name: /convert/i }));
+  await screen.findByText(/Execution time/);
+  await screen.findByDisplayValue('hello');
+  fireEvent.click(screen.getByRole('tab', { name: 'JSON' }));
+  await screen.findByText('markdown');
+});

--- a/frontend/src/pages/MarkdownPage.tsx
+++ b/frontend/src/pages/MarkdownPage.tsx
@@ -1,0 +1,120 @@
+import { useState } from 'react';
+import { Card, Form, Upload, Button, Tabs } from 'antd';
+import InboxOutlined from '@ant-design/icons/InboxOutlined';
+import MDEditor from '@uiw/react-md-editor';
+import JsonView from '@uiw/react-json-view';
+import { githubLightTheme } from '@uiw/react-json-view/githubLight';
+import { ApiError, OpenAPI } from '../generated';
+import { request as __request } from '../generated/core/request';
+import { validateFile } from './JobNew';
+import { useApiError } from '../components/ApiErrorProvider';
+
+export async function convertFile(file: File) {
+  const res = await __request(OpenAPI, {
+    method: 'POST',
+    url: '/api/v1/markdown',
+    formData: { file },
+    mediaType: 'multipart/form-data',
+  });
+  return typeof res === 'string' ? JSON.parse(res) : res;
+}
+
+export default function MarkdownPage() {
+  const [file, setFile] = useState<File | null>(null);
+  const [result, setResult] = useState<any>(null);
+  const [elapsed, setElapsed] = useState<number | null>(null);
+  const [loading, setLoading] = useState(false);
+  const { showError } = useApiError();
+
+  const handleConvert = async () => {
+    if (!file) {
+      showError('File is required');
+      return;
+    }
+    const err = validateFile(file);
+    if (err) {
+      showError(err);
+      return;
+    }
+    setLoading(true);
+    const start = performance.now();
+    try {
+      const res = await convertFile(file);
+      setResult(res);
+      setElapsed(performance.now() - start);
+    } catch (e) {
+      if (e instanceof ApiError) showError(e.body?.detail || e.message);
+      else if (e instanceof Error) showError(e.message);
+      else showError(String(e));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Card>
+      <Form layout="vertical">
+        <Form.Item label="File" required>
+          <Upload.Dragger
+            maxCount={1}
+            beforeUpload={(f) => {
+              const e = validateFile(f);
+              if (e) {
+                showError(e);
+                return Upload.LIST_IGNORE;
+              }
+              setFile(f);
+              return false;
+            }}
+          >
+            <p className="ant-upload-drag-icon">
+              <InboxOutlined />
+            </p>
+            <p className="ant-upload-text">Drag or click to upload</p>
+            {file && (
+              <p>
+                {file.name} ({(file.size / 1024).toFixed(1)} KB)
+              </p>
+            )}
+          </Upload.Dragger>
+        </Form.Item>
+        <Form.Item>
+          <Button type="primary" onClick={handleConvert} loading={loading}>
+            Convert
+          </Button>
+        </Form.Item>
+      </Form>
+      {result && (
+        <>
+          {elapsed !== null && (
+            <p>Execution time: {elapsed.toFixed(0)} ms</p>
+          )}
+          <Tabs
+            items={[
+              {
+                key: 'md',
+                label: 'Markdown',
+                children: (
+                  <MDEditor
+                    value={result.markdown}
+                    preview="edit"
+                    hideToolbar
+                    height={400}
+                    textareaProps={{ readOnly: true }}
+                  />
+                ),
+              },
+              {
+                key: 'json',
+                label: 'JSON',
+                children: (
+                  <JsonView value={result} style={githubLightTheme} />
+                ),
+              },
+            ]}
+          />
+        </>
+      )}
+    </Card>
+  );
+}

--- a/src/DocflowAi.Net.Api/Markdown/Endpoints/MarkdownEndpoints.cs
+++ b/src/DocflowAi.Net.Api/Markdown/Endpoints/MarkdownEndpoints.cs
@@ -13,11 +13,12 @@ public static class MarkdownEndpoints
     {
         var group = builder.MapGroup("/api/v1/markdown")
             .WithTags("Markdown")
-            .RequireRateLimiting("General");
+            .RequireRateLimiting("General")
+            .RequireAuthorization();
 
         group.MapPost(string.Empty, ConvertFileAsync)
         .Accepts<IFormFile>("multipart/form-data")
-        .Produces<string>(StatusCodes.Status200OK, "text/plain")
+        .Produces<MarkdownResult>(StatusCodes.Status200OK, "application/json")
         .Produces<ErrorResponse>(StatusCodes.Status400BadRequest)
         .WithName("Markdown_Convert");
 
@@ -37,6 +38,6 @@ public static class MarkdownEndpoints
         else
             result = await conv.ConvertImageAsync(stream, opts.Value);
 
-        return Results.Text(result.Markdown, "text/plain");
+        return Results.Json(result);
     }
 }

--- a/tests/DocflowAi.Net.Api.Tests/MarkdownAuthTests.cs
+++ b/tests/DocflowAi.Net.Api.Tests/MarkdownAuthTests.cs
@@ -1,0 +1,26 @@
+using System.Linq;
+using DocflowAi.Net.Api.Tests.Fixtures;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace DocflowAi.Net.Api.Tests;
+
+[Trait("Category","MarkdownEndpoints")]
+public class MarkdownAuthTests : IClassFixture<TempDirFixture>
+{
+    private readonly TempDirFixture _fx;
+    public MarkdownAuthTests(TempDirFixture fx) => _fx = fx;
+
+    [Fact]
+    public async Task Endpoint_requires_authorization()
+    {
+        await using var factory = new TestWebAppFactory(_fx.RootPath);
+        var data = factory.Services.GetRequiredService<EndpointDataSource>();
+        var endpoint = data.Endpoints.OfType<RouteEndpoint>()
+            .First(e => e.RoutePattern.RawText?.StartsWith("/api/v1/markdown") == true);
+        endpoint.Metadata.GetMetadata<IAuthorizeData>().Should().NotBeNull();
+    }
+}

--- a/tests/DocflowAi.Net.Api.Tests/MarkdownEndpointTests.cs
+++ b/tests/DocflowAi.Net.Api.Tests/MarkdownEndpointTests.cs
@@ -13,7 +13,7 @@ namespace DocflowAi.Net.Api.Tests;
 public class MarkdownEndpointTests
 {
     [Fact]
-    public async Task Convert_returns_markdown_text()
+    public async Task Convert_returns_markdown_json()
     {
         var file = new FormFile(new MemoryStream(new byte[] {1,2,3}), 0, 3, "file", "test.png");
         var result = await MarkdownEndpoints.ConvertFileAsync(file, new FakeMarkdownConverter(), Microsoft.Extensions.Options.Options.Create(new MarkdownOptions()));
@@ -23,8 +23,9 @@ public class MarkdownEndpointTests
         ctx.Response.Body = ms;
         await result.ExecuteAsync(ctx);
         ms.Position = 0;
-        var text = await new StreamReader(ms).ReadToEndAsync();
-        Assert.Equal("FAKE", text);
+        var json = await new StreamReader(ms).ReadToEndAsync();
+        var obj = System.Text.Json.JsonSerializer.Deserialize<MarkdownResult>(json, new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        Assert.Equal("FAKE", obj!.Markdown);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- secure markdown conversion API with authorization and JSON result
- add frontend markdown converter with execution time, editor, and JSON viewer
- cover markdown endpoint with tests

## Testing
- `dotnet build -c Release`
- `dotnet test -c Release`
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4968a971c8325a8176d3cc932f4d2