### PR TITLE
Add integration test for payroll images

### DIFF
--- a/docs/busta-paga-results.md
+++ b/docs/busta-paga-results.md
@@ -1,12 +1,14 @@
 # Pay slip dataset analysis
 
-All pay slip conversions failed. Server logs show `Tesseract.Interop.LeptonicaApi.Initialize` could not load native dependencies, preventing Markdown generation.
+All pay slip conversions failed due to a Leptonica library load error (`libleptonica-1.82.0.so`), so no content or timing metrics were generated.
 
 | File | Error | Details |
 | --- | --- | --- |
-| busta_paga_01.jpg | Leptonica initialization failed | [link](./busta-paga/busta_paga_01.md) |
-| busta_paga_02.jpg | Leptonica initialization failed | [link](./busta-paga/busta_paga_02.md) |
-| busta_paga_03.jpg | Leptonica initialization failed | [link](./busta-paga/busta_paga_03.md) |
-| busta_paga_05.png | Leptonica initialization failed | [link](./busta-paga/busta_paga_05.md) |
+| busta_paga_01.jpg | Leptonica library load failure | [link](./busta-paga/busta_paga_01.md) |
+| busta_paga_02.jpg | Leptonica library load failure | [link](./busta-paga/busta_paga_02.md) |
+| busta_paga_03.jpg | Leptonica library load failure | [link](./busta-paga/busta_paga_03.md) |
+| busta_paga_05.png | Leptonica library load failure | [link](./busta-paga/busta_paga_05.md) |
 
-No timing information or field values are available.
+The native Tesseract and Leptonica libraries ship with the project under `src/MarkItDownNet/TesseractOCR/x64` and are copied next to the binaries during build; verify they are available when running the converter.
+
+No timing information or extracted fields are available.

--- a/docs/busta-paga/busta_paga_01.md
+++ b/docs/busta-paga/busta_paga_01.md
@@ -1,3 +1,5 @@
 # busta_paga_01.jpg
 
-Conversion failed: `Tesseract.Interop.LeptonicaApi.Initialize` could not load native dependencies, so no markdown or fields were produced.
+Conversion failed: Failed to find library "libleptonica-1.82.0.so" for platform x64.
+
+The required Tesseract and Leptonica libraries are bundled under `src/MarkItDownNet/TesseractOCR/x64`; ensure they are copied alongside the binaries.

--- a/docs/busta-paga/busta_paga_02.md
+++ b/docs/busta-paga/busta_paga_02.md
@@ -1,3 +1,5 @@
 # busta_paga_02.jpg
 
-Conversion failed: `Tesseract.Interop.LeptonicaApi.Initialize` could not load native dependencies, so no markdown or fields were produced.
+Conversion failed: Failed to find library "libleptonica-1.82.0.so" for platform x64.
+
+The required Tesseract and Leptonica libraries are bundled under `src/MarkItDownNet/TesseractOCR/x64`; ensure they are copied alongside the binaries.

--- a/docs/busta-paga/busta_paga_03.md
+++ b/docs/busta-paga/busta_paga_03.md
@@ -1,3 +1,5 @@
 # busta_paga_03.jpg
 
-Conversion failed: `Tesseract.Interop.LeptonicaApi.Initialize` could not load native dependencies, so no markdown or fields were produced.
+Conversion failed: Failed to find library "libleptonica-1.82.0.so" for platform x64.
+
+The required Tesseract and Leptonica libraries are bundled under `src/MarkItDownNet/TesseractOCR/x64`; ensure they are copied alongside the binaries.

--- a/docs/busta-paga/busta_paga_05.md
+++ b/docs/busta-paga/busta_paga_05.md
@@ -1,3 +1,5 @@
 # busta_paga_05.png
 
-Conversion failed: `Tesseract.Interop.LeptonicaApi.Initialize` could not load native dependencies, so no markdown or fields were produced.
+Conversion failed: Failed to find library "libleptonica-1.82.0.so" for platform x64.
+
+The required Tesseract and Leptonica libraries are bundled under `src/MarkItDownNet/TesseractOCR/x64`; ensure they are copied alongside the binaries.

--- a/src/DocflowAi.Net.Api/Markdown/Endpoints/MarkdownEndpoints.cs
+++ b/src/DocflowAi.Net.Api/Markdown/Endpoints/MarkdownEndpoints.cs
@@ -1,6 +1,8 @@
+using System;
 using DocflowAi.Net.Application.Abstractions;
 using DocflowAi.Net.Application.Markdown;
 using DocflowAi.Net.Api.Contracts;
+using DocflowAi.Net.Infrastructure.Markdown;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.Extensions.Options;
@@ -20,6 +22,8 @@ public static class MarkdownEndpoints
         .Accepts<IFormFile>("multipart/form-data")
         .Produces<MarkdownResult>(StatusCodes.Status200OK, "application/json")
         .Produces<ErrorResponse>(StatusCodes.Status400BadRequest)
+        .Produces<ErrorResponse>(StatusCodes.Status422UnprocessableEntity)
+        .Produces<ErrorResponse>(StatusCodes.Status500InternalServerError)
         .WithName("Markdown_Convert");
 
         return builder;
@@ -31,13 +35,29 @@ public static class MarkdownEndpoints
             return Results.Json(new ErrorResponse("bad_request", "file required"), statusCode: 400);
 
         await using var stream = file.OpenReadStream();
-        MarkdownResult result;
-        var ext = Path.GetExtension(file.FileName).ToLowerInvariant();
-        if (ext == ".pdf")
-            result = await conv.ConvertPdfAsync(stream, opts.Value);
-        else
-            result = await conv.ConvertImageAsync(stream, opts.Value);
+        try
+        {
+            MarkdownResult result;
+            var ext = Path.GetExtension(file.FileName).ToLowerInvariant();
+            if (ext == ".pdf")
+                result = await conv.ConvertPdfAsync(stream, opts.Value);
+            else
+                result = await conv.ConvertImageAsync(stream, opts.Value);
 
-        return Results.Json(result);
+            return Results.Json(result);
+        }
+        catch (MarkdownConversionException ex)
+        {
+            var status = ex.Code == "unsupported_format" ? 400 : 422;
+            return Results.Json(new ErrorResponse(ex.Code, ex.Message), statusCode: status);
+        }
+        catch (DllNotFoundException ex)
+        {
+            return Results.Json(new ErrorResponse("native_library_missing", ex.Message), statusCode: 500);
+        }
+        catch (Exception ex)
+        {
+            return Results.Json(new ErrorResponse("markdown_conversion_failed", ex.Message), statusCode: 500);
+        }
     }
 }

--- a/tests/DocflowAi.Net.Api.Tests/Fakes/ThrowingMarkdownConverter.cs
+++ b/tests/DocflowAi.Net.Api.Tests/Fakes/ThrowingMarkdownConverter.cs
@@ -1,0 +1,27 @@
+using System;
+using DocflowAi.Net.Application.Abstractions;
+using DocflowAi.Net.Application.Markdown;
+using DocflowAi.Net.Infrastructure.Markdown;
+
+namespace DocflowAi.Net.Api.Tests.Fakes;
+
+public sealed class ThrowingMarkdownConverter : IMarkdownConverter
+{
+    private readonly Exception _exception;
+
+    public ThrowingMarkdownConverter(string code)
+        : this(new MarkdownConversionException(code, "fail"))
+    {
+    }
+
+    public ThrowingMarkdownConverter(Exception exception)
+    {
+        _exception = exception;
+    }
+
+    public Task<MarkdownResult> ConvertPdfAsync(Stream pdf, MarkdownOptions opts, CancellationToken ct = default)
+        => Task.FromException<MarkdownResult>(_exception);
+
+    public Task<MarkdownResult> ConvertImageAsync(Stream image, MarkdownOptions opts, CancellationToken ct = default)
+        => Task.FromException<MarkdownResult>(_exception);
+}

--- a/tests/DocflowAi.Net.Tests.Integration/DatasetMarkdownNetTests.cs
+++ b/tests/DocflowAi.Net.Tests.Integration/DatasetMarkdownNetTests.cs
@@ -77,4 +77,21 @@ public class DatasetMarkdownNetTests
             result.Markdown.Should().Contain(w);
         }
     }
+
+    [Fact]
+    public async Task PayrollImages_AreConvertibleToMarkdown()
+    {
+        if (!HasTesseract) return;
+        var payrollDir = Path.Combine(Root, "dataset", "busta-paga");
+        foreach (var imgPath in Directory.EnumerateFiles(payrollDir)
+                     .Where(p => p.EndsWith(".jpg", StringComparison.OrdinalIgnoreCase) ||
+                                 p.EndsWith(".png", StringComparison.OrdinalIgnoreCase)))
+        {
+            await using var fs = File.OpenRead(imgPath);
+            var result = await _converter.ConvertImageAsync(fs, new MarkdownOptions());
+            result.Markdown.Should().NotBeNullOrWhiteSpace();
+            result.Boxes.Should().NotBeNull();
+            result.Boxes.Should().NotBeEmpty();
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- test all payroll dataset images for successful markdown conversion
- document missing Leptonica library preventing payroll dataset conversion
- return 500 error with code `native_library_missing` when converter cannot load Tesseract or Leptonica

## Testing
- `rg -n -i 'pytest|:8000|sidecar|MarkitdownException|MARKITDOWN_URL|PY_MARKITDOWN_ENABLED' --glob '!*AGENTS.md'`
- `dotnet build -c Release`
- `dotnet test tests/DocflowAi.Net.Api.Tests -c Release --no-build`
- `dotnet test tests/DocflowAi.Net.BBoxResolver.Tests -c Release --no-build`
- `dotnet test tests/DocflowAi.Net.Tests.Unit -c Release --no-build`
- `dotnet test tests/XFundEvalRunner.Tests -c Release --no-build`
- `dotnet test tests/DocflowAi.Net.Tests.Integration -c Release --no-build`
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4b99b2eb883259c853b55158b37dc