### PR TITLE
Disable antiforgery for markdown upload endpoint

### DIFF
--- a/src/DocflowAi.Net.Api/Markdown/Endpoints/MarkdownEndpoints.cs
+++ b/src/DocflowAi.Net.Api/Markdown/Endpoints/MarkdownEndpoints.cs
@@ -5,6 +5,7 @@ using DocflowAi.Net.Api.Contracts;
 using DocflowAi.Net.Infrastructure.Markdown;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Options;
 
 namespace DocflowAi.Net.Api.Markdown.Endpoints;
@@ -17,6 +18,8 @@ public static class MarkdownEndpoints
             .WithTags("Markdown")
             .RequireRateLimiting("General")
             .RequireAuthorization();
+
+        group.DisableAntiforgery();
 
         group.MapPost(string.Empty, ConvertFileAsync)
         .Accepts<IFormFile>("multipart/form-data")


### PR DESCRIPTION
## Summary
- disable automatic antiforgery for Markdown upload API to avoid middleware errors

## Testing
- `rg -n -i 'pytest|:8000|sidecar|MarkitdownException|MARKITDOWN_URL|PY_MARKITDOWN_ENABLED' -g '!AGENTS.md'`
- `dotnet build -c Release`
- `dotnet test -c Release`
- `npm test -- --run`
- `CI=1 npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4d4e436c48325a5c9a340541c0bd0