### PR TITLE
Fix Tesseract library path

### DIFF
--- a/src/DocflowAi.Net.Infrastructure/Markdown/MarkdownNetConverter.cs
+++ b/src/DocflowAi.Net.Infrastructure/Markdown/MarkdownNetConverter.cs
@@ -5,6 +5,7 @@ using MkdnOptions = MarkItDownNet.MarkIt\u0044ownOptions;
 using Microsoft.Extensions.Logging;
 using Serilog;
 using Serilog.Events;
+using Tesseract;
 
 namespace DocflowAi.Net.Infrastructure.Markdown;
 
@@ -49,6 +50,7 @@ public sealed class MarkdownNetConverter : IMarkdownConverter
                 MinimumNativeWordThreshold = opts.MinimumNativeWordThreshold
             };
             var converter = new MkdnConverter(options, _mdLogger);
+            TesseractEnviornment.CustomSearchPath = Path.Combine(AppContext.BaseDirectory, "x64");
             var res = await converter.ConvertAsync(tmp, mime, ct);
 
             var pages = res.Pages.Select(p => new PageInfo(p.Number, p.Width, p.Height)).ToList();


### PR DESCRIPTION
## Summary
- ensure MarkItDownNet converter locates bundled native libraries

## Testing
- `rg -n -i 'pytest|:8000|sidecar|MarkitdownException|MARKITDOWN_URL|PY_MARKITDOWN_ENABLED' -g '!AGENTS.md'`
- `dotnet build -c Release`
- `dotnet test -c Release`
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a56fdb66b083258a2e15eaef66155f