### PR TITLE
Hide download action for downloaded models

### DIFF
--- a/frontend/src/pages/ModelsPage.test.tsx
+++ b/frontend/src/pages/ModelsPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import ModelsPage from './ModelsPage';
 import { ModelsService } from '../generated';
@@ -20,10 +20,10 @@ vi.mock('../components/ModelModal', () => ({
 }));
 
 vi.mock('../generated', () => {
-  const list = [
-    {
-      id: '1',
-      name: 'host',
+    const list = [
+      {
+        id: '1',
+        name: 'host',
       type: 'hosted-llm',
       provider: 'openai',
       baseUrl: 'https://x',
@@ -50,10 +50,26 @@ vi.mock('../generated', () => {
       lastUsedAt: null,
       hasApiKey: false,
       hasHfToken: true,
-      createdAt: '2024-01-03T00:00:00Z',
-      updatedAt: '2024-01-04T00:00:00Z',
-    },
-  ];
+        createdAt: '2024-01-03T00:00:00Z',
+        updatedAt: '2024-01-04T00:00:00Z',
+      },
+      {
+        id: '3',
+        name: 'downloaded',
+        type: 'local',
+        provider: null,
+        baseUrl: null,
+        hfRepo: 'repo',
+        modelFile: 'file',
+        downloaded: true,
+        downloadStatus: 'Downloaded',
+        lastUsedAt: null,
+        hasApiKey: false,
+        hasHfToken: true,
+        createdAt: '2024-01-05T00:00:00Z',
+        updatedAt: '2024-01-06T00:00:00Z',
+      },
+    ];
   return {
     ModelsService: {
       modelsList: vi.fn().mockResolvedValue(list),
@@ -74,6 +90,7 @@ describe('ModelsPage', () => {
     await waitFor(() => {
       expect(screen.queryByText('host')).toBeNull();
       expect(screen.getByText('local')).toBeInTheDocument();
+      expect(screen.getByText('downloaded')).toBeInTheDocument();
     });
   });
 
@@ -86,10 +103,18 @@ describe('ModelsPage', () => {
     });
   });
 
+  it('does not show download button for already downloaded model', async () => {
+    render(<ModelsPage />);
+    const nameCells = await screen.findAllByText('downloaded');
+    const row = nameCells[0].closest('tr') || nameCells[0].closest('li');
+    expect(row).not.toBeNull();
+    expect(within(row as HTMLElement).queryByLabelText('Start download')).toBeNull();
+  });
+
   it('shows actions for hosted model', async () => {
     render(<ModelsPage />);
     await screen.findAllByText('host');
-    expect(screen.getByLabelText('Edit model')).toBeInTheDocument();
+    expect(screen.getAllByLabelText('Edit model').length).toBeGreaterThan(0);
     expect(screen.getAllByLabelText('Delete model').length).toBeGreaterThan(0);
   });
 

--- a/frontend/src/pages/ModelsPage.tsx
+++ b/frontend/src/pages/ModelsPage.tsx
@@ -122,15 +122,17 @@ export default function ModelsPage() {
           )}
           {record.type === 'local' && (
             <>
-              <Button
-                icon={<DownloadOutlined />}
-                aria-label="Start download"
-                onClick={async () => {
-                  await ModelsService.modelsStartDownload({ id: record.id! });
-                  notify('success', 'Download started');
-                  load();
-                }}
-              />
+              {!record.downloaded && (
+                <Button
+                  icon={<DownloadOutlined />}
+                  aria-label="Start download"
+                  onClick={async () => {
+                    await ModelsService.modelsStartDownload({ id: record.id! });
+                    notify('success', 'Download started');
+                    load();
+                  }}
+                />
+              )}
               <Button
                 icon={<FileTextOutlined />}
                 aria-label="View log"
@@ -200,16 +202,20 @@ export default function ModelsPage() {
               actions={
                 r.type === 'local'
                   ? [
-                      <Button
-                        key="download"
-                        icon={<DownloadOutlined />}
-                        aria-label="Start download"
-                        onClick={async () => {
-                          await ModelsService.modelsStartDownload({ id: r.id! });
-                          notify('success', 'Download started');
-                          load();
-                        }}
-                      />,
+                      ...(r.downloaded
+                        ? []
+                        : [
+                            <Button
+                              key="download"
+                              icon={<DownloadOutlined />}
+                              aria-label="Start download"
+                              onClick={async () => {
+                                await ModelsService.modelsStartDownload({ id: r.id! });
+                                notify('success', 'Download started');
+                                load();
+                              }}
+                            />,
+                          ]),
                       <Button
                         key="log"
                         icon={<FileTextOutlined />}


### PR DESCRIPTION
## Summary
- hide download button for models that are already downloaded
- add regression test for hiding the download action

## Testing
- `rg -n -i 'pytest|:8000|sidecar|MarkitdownException|MARKITDOWN_URL|PY_MARKITDOWN_ENABLED'`
- `dotnet build -c Release`
- `dotnet test -c Release`
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a59e3f63a08325b5a6dd53a313e51a