### PR TITLE
Enable Hangfire console logging

### DIFF
--- a/src/DocflowAi.Net.Api/DocflowAi.Net.Api.csproj
+++ b/src/DocflowAi.Net.Api/DocflowAi.Net.Api.csproj
@@ -33,7 +33,6 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0" />
     <PackageReference Include="Polly" Version="8.3.1" />
-    <PackageReference Include="Hangfire.Console" Version="1.4.2" />
     <PackageReference Include="Hangfire.Console.Extensions" Version="2.0.0" />
     <PackageReference Include="Hangfire.Console.Extensions.Serilog" Version="2.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/src/DocflowAi.Net.Api/Program.cs
+++ b/src/DocflowAi.Net.Api/Program.cs
@@ -46,6 +46,7 @@ using Hangfire.Dashboard;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using DocflowAi.Net.Infrastructure.Security;
 using Hangfire.Console.Extensions;
+using Hangfire.Console;
 using Microsoft.Data.Sqlite;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -138,6 +139,8 @@ builder.Services.AddHostedService(sp => sp.GetRequiredService<CleanupService>())
 
 builder.Services.AddHangfire(config =>
 {
+    config.UseSerilogLogProvider();
+    config.UseConsole(new ConsoleOptions());
     config.UseSimpleAssemblyNameTypeSerializer()
           .UseRecommendedSerializerSettings()
           .UseMemoryStorage();

--- a/tests/DocflowAi.Net.Api.Tests/HangfireConsoleExtensionsTests.cs
+++ b/tests/DocflowAi.Net.Api.Tests/HangfireConsoleExtensionsTests.cs
@@ -1,7 +1,9 @@
 using DocflowAi.Net.Api.Tests.Fixtures;
 using FluentAssertions;
+using Hangfire;
 using Hangfire.Console.Extensions;
 using Microsoft.Extensions.DependencyInjection;
+using System.Linq;
 
 namespace DocflowAi.Net.Api.Tests;
 
@@ -16,5 +18,8 @@ public class HangfireConsoleExtensionsTests : IClassFixture<TempDirFixture>
         using var factory = new TestWebAppFactory(_fx.RootPath);
         var manager = factory.Services.GetService<IJobManager>();
         manager.Should().NotBeNull();
+        GlobalJobFilters.Filters
+            .Any(f => f.Instance.GetType().Name == "ConsoleServerFilter")
+            .Should().BeTrue();
     }
 }


### PR DESCRIPTION
## Summary
- configure Hangfire to log via Serilog and Hangfire.Console
- remove duplicate Hangfire.Console package reference
- assert Hangfire console filter registration

## Testing
- `rg -n -i 'pytest|:8000|sidecar|MarkitdownException|MARKITDOWN_URL|PY_MARKITDOWN_ENABLED'`
- `dotnet build -c Release`
- `dotnet test -c Release`
- `cd frontend && npm ci`
- `cd frontend && npm test -- --run`
- `cd frontend && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5a70921dc8325b069836a7e631f9a