### PR TITLE
Fix input file visibility in job details

### DIFF
--- a/frontend/src/generated/index.ts
+++ b/frontend/src/generated/index.ts
@@ -7,17 +7,20 @@ export { CancelablePromise, CancelError } from './core/CancelablePromise';
 export { OpenAPI } from './core/OpenAPI';
 export type { OpenAPIConfig } from './core/OpenAPI';
 
+export type { Box } from './models/Box';
 export type { CreateModelRequest } from './models/CreateModelRequest';
 export type { CreateTemplateRequest } from './models/CreateTemplateRequest';
 export type { DownloadModelRequest } from './models/DownloadModelRequest';
 export type { ErrorResponse } from './models/ErrorResponse';
 export type { JobDetailResponse } from './models/JobDetailResponse';
 export type { JobSummary } from './models/JobSummary';
+export type { MarkdownResult } from './models/MarkdownResult';
 export type { MetricsInfo } from './models/MetricsInfo';
 export type { ModelDownloadStatus } from './models/ModelDownloadStatus';
 export type { ModelDto } from './models/ModelDto';
 export type { ModelInfo } from './models/ModelInfo';
 export type { PagedJobsResponse } from './models/PagedJobsResponse';
+export type { PageInfo } from './models/PageInfo';
 export type { PathInfo } from './models/PathInfo';
 export type { SubmitAcceptedResponse } from './models/SubmitAcceptedResponse';
 export type { SwitchModelRequest } from './models/SwitchModelRequest';
@@ -29,6 +32,7 @@ export type { UpdateTemplateRequest } from './models/UpdateTemplateRequest';
 export type { Void } from './models/Void';
 
 export { JobsService } from './services/JobsService';
+export { MarkdownService } from './services/MarkdownService';
 export { ModelService } from './services/ModelService';
 export { ModelsService } from './services/ModelsService';
 export { TemplatesService } from './services/TemplatesService';

--- a/frontend/src/generated/services/MarkdownService.ts
+++ b/frontend/src/generated/services/MarkdownService.ts
@@ -1,0 +1,33 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { MarkdownResult } from '../models/MarkdownResult';
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { OpenAPI } from '../core/OpenAPI';
+import { request as __request } from '../core/request';
+export class MarkdownService {
+    /**
+     * @returns MarkdownResult OK
+     * @throws ApiError
+     */
+    public static markdownConvert({
+        formData,
+    }: {
+        formData?: {
+            file?: Blob;
+        },
+    }): CancelablePromise<MarkdownResult> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v1/markdown',
+            formData: formData,
+            mediaType: 'multipart/form-data',
+            errors: {
+                400: `Bad Request`,
+                422: `Unprocessable Content`,
+                500: `Internal Server Error`,
+            },
+        });
+    }
+}

--- a/frontend/src/pages/JobDetail.test.tsx
+++ b/frontend/src/pages/JobDetail.test.tsx
@@ -1,6 +1,6 @@
 import { render, waitFor, screen, cleanup, fireEvent } from '@testing-library/react';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
-import { test, vi, expect } from 'vitest';
+import { test, vi, expect, afterEach } from 'vitest';
 import JobDetail from './JobDetail';
 import {
   JobsService,
@@ -21,6 +21,11 @@ vi.mock('antd', async () => {
 const getByIdSpy = vi.spyOn(JobsService, 'jobsGetById');
 vi.spyOn(ModelsService, 'modelsList').mockResolvedValue([] as any);
 vi.spyOn(TemplatesService, 'templatesList').mockResolvedValue({ items: [] } as any);
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
 
 test('shows error when job is missing', async () => {
   getByIdSpy.mockReset();
@@ -95,7 +100,7 @@ test('shows duration in seconds with suffix', async () => {
 
 test('shows reload and cancel only when running', async () => {
   getByIdSpy.mockReset();
-  getByIdSpy.mockResolvedValueOnce({
+  getByIdSpy.mockResolvedValue({
     id: '1',
     status: 'Running',
     attempts: 1,
@@ -105,9 +110,10 @@ test('shows reload and cancel only when running', async () => {
     updatedAt: '',
     paths: { input: '/input.pdf' },
   } as any);
-  const fetchSpy = vi
-    .spyOn(global, 'fetch')
-    .mockResolvedValue({ ok: true, headers: new Headers() } as any);
+  const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue({
+    ok: true,
+    headers: new Headers(),
+  } as any);
   render(
     <ApiErrorProvider>
       <MemoryRouter initialEntries={['/jobs/1']}>
@@ -119,17 +125,16 @@ test('shows reload and cancel only when running', async () => {
   );
   await waitFor(() => screen.getByText('Reload'));
   expect(screen.getByText('Cancel')).toBeInTheDocument();
-  expect(fetchSpy).toHaveBeenCalledTimes(1);
-  expect(fetchSpy).toHaveBeenCalledWith(
-    expect.stringContaining('/input.pdf'),
-    expect.objectContaining({ method: 'HEAD' }),
-  );
+  const filesTab = screen.getAllByRole('tab', { name: 'Files' })[0];
+  fireEvent.click(filesTab);
+  await waitFor(() => screen.getByText('input'));
+  expect(fetchSpy).not.toHaveBeenCalled();
   fetchSpy.mockRestore();
 
   cleanup();
 
   getByIdSpy.mockReset();
-  getByIdSpy.mockResolvedValueOnce({
+  getByIdSpy.mockResolvedValue({
     id: '1',
     status: 'Succeeded',
     attempts: 1,
@@ -138,7 +143,9 @@ test('shows reload and cancel only when running', async () => {
     createdAt: '',
     updatedAt: '',
   } as any);
-  vi.spyOn(global, 'fetch').mockResolvedValue({ ok: true, headers: new Headers() } as any);
+  const fetchSpy2 = vi
+    .spyOn(global, 'fetch')
+    .mockResolvedValue({ ok: true, headers: new Headers() } as any);
   render(
     <ApiErrorProvider>
       <MemoryRouter initialEntries={['/jobs/1']}>
@@ -148,9 +155,12 @@ test('shows reload and cancel only when running', async () => {
       </MemoryRouter>
     </ApiErrorProvider>,
   );
-  await waitFor(() => expect(screen.getAllByText('Attempts').length).toBeGreaterThan(0));
+  await waitFor(() =>
+    expect(screen.getAllByText('Attempts').length).toBeGreaterThan(0),
+  );
   expect(screen.queryByText('Reload')).toBeNull();
   expect(screen.queryByText('Cancel')).toBeNull();
+  expect(fetchSpy2).not.toHaveBeenCalled();
 });
 
 

--- a/frontend/src/pages/JobDetail.test.tsx
+++ b/frontend/src/pages/JobDetail.test.tsx
@@ -163,6 +163,38 @@ test('shows reload and cancel only when running', async () => {
   expect(fetchSpy2).not.toHaveBeenCalled();
 });
 
+test('lists markdown file while running', async () => {
+  getByIdSpy.mockReset();
+  getByIdSpy.mockResolvedValueOnce({
+    id: '1',
+    status: 'Running',
+    attempts: 1,
+    model: 'm',
+    templateToken: 't',
+    createdAt: '',
+    updatedAt: '',
+    paths: { input: '/i.pdf', markdown: '/m.md' },
+  } as any);
+  const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue({
+    ok: true,
+    headers: new Headers(),
+  } as any);
+  render(
+    <ApiErrorProvider>
+      <MemoryRouter initialEntries={['/jobs/1']}>
+        <Routes>
+          <Route path="/jobs/:id" element={<JobDetail />} />
+        </Routes>
+      </MemoryRouter>
+    </ApiErrorProvider>,
+  );
+  await waitFor(() => screen.getByText('Reload'));
+  const filesTab = screen.getAllByRole('tab', { name: 'Files' })[0];
+  fireEvent.click(filesTab);
+  await waitFor(() => screen.getByText('markdown'));
+  expect(fetchSpy).not.toHaveBeenCalled();
+});
+
 test('lists all paths without extra requests', async () => {
   getByIdSpy.mockReset();
   getByIdSpy.mockResolvedValueOnce({

--- a/frontend/src/pages/JobDetail.test.tsx
+++ b/frontend/src/pages/JobDetail.test.tsx
@@ -193,4 +193,40 @@ test('lists all paths without extra requests', async () => {
   expect(fetchSpy).not.toHaveBeenCalled();
 });
 
+test('previews markdown file', async () => {
+  getByIdSpy.mockReset();
+  getByIdSpy.mockResolvedValueOnce({
+    id: '1',
+    status: 'Succeeded',
+    attempts: 1,
+    model: 'm',
+    templateToken: 't',
+    createdAt: '',
+    updatedAt: '',
+    paths: { input: '/input.pdf', markdown: '/markdown.md' },
+  } as any);
+  const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue({
+    ok: true,
+    headers: new Headers({ 'content-type': 'text/markdown' }),
+    text: async () => '# hi',
+  } as any);
+  render(
+    <ApiErrorProvider>
+      <MemoryRouter initialEntries={['/jobs/1']}>
+        <Routes>
+          <Route path="/jobs/:id" element={<JobDetail />} />
+        </Routes>
+      </MemoryRouter>
+    </ApiErrorProvider>,
+  );
+  await waitFor(() => screen.getByText('Attempts'));
+  const filesTab = screen.getAllByRole('tab', { name: 'Files' })[0];
+  fireEvent.click(filesTab);
+  await waitFor(() => screen.getByText('markdown'));
+  const previewBtn = screen.getByLabelText('Preview');
+  fireEvent.click(previewBtn);
+  await waitFor(() => screen.getByText('hi'));
+  expect(fetchSpy).toHaveBeenCalledTimes(1);
+});
+
 

--- a/frontend/src/pages/JobDetail.test.tsx
+++ b/frontend/src/pages/JobDetail.test.tsx
@@ -163,4 +163,34 @@ test('shows reload and cancel only when running', async () => {
   expect(fetchSpy2).not.toHaveBeenCalled();
 });
 
+test('lists all paths without extra requests', async () => {
+  getByIdSpy.mockReset();
+  getByIdSpy.mockResolvedValueOnce({
+    id: '1',
+    status: 'Failed',
+    attempts: 1,
+    model: 'm',
+    templateToken: 't',
+    createdAt: '',
+    updatedAt: '',
+    paths: { input: '/input.pdf', error: '/error.txt' },
+  } as any);
+  const fetchSpy = vi.spyOn(global, 'fetch');
+  render(
+    <ApiErrorProvider>
+      <MemoryRouter initialEntries={['/jobs/1']}>
+        <Routes>
+          <Route path="/jobs/:id" element={<JobDetail />} />
+        </Routes>
+      </MemoryRouter>
+    </ApiErrorProvider>,
+  );
+  await waitFor(() => screen.getByText('Attempts'));
+  const filesTab = screen.getAllByRole('tab', { name: 'Files' })[0];
+  fireEvent.click(filesTab);
+  await waitFor(() => screen.getByText('input'));
+  expect(screen.getByText('error')).toBeInTheDocument();
+  expect(fetchSpy).not.toHaveBeenCalled();
+});
+
 

--- a/frontend/src/pages/JobDetail.tsx
+++ b/frontend/src/pages/JobDetail.tsx
@@ -146,42 +146,16 @@ export default function JobDetail() {
   }, [job]);
 
   useEffect(() => {
-    const loadFiles = async () => {
-      if (!job) return;
-      const entries = Object.entries(job.paths || {}).filter(([k, v]) => {
-        if (!v) return false;
-        if (k === 'error' && job.status === 'Succeeded') return false;
-        if (k === 'output' && job.status === 'Running') return false;
-        return true;
-      });
-      const checks = await Promise.all(
-        entries.map(async ([k, v]) => {
-          if (k === 'input') {
-            return { key: k, label: k, path: v as string };
-          }
-          let url = v as string;
-          if (!url.startsWith('http')) url = `${OpenAPI.BASE}${v}`;
-          try {
-            const resp = await fetch(url, {
-              method: 'HEAD',
-              headers: OpenAPI.HEADERS as Record<string, string> | undefined,
-            });
-            if (resp.ok) {
-              return { key: k, label: k, path: v as string };
-            }
-          } catch {
-            /* ignore */
-          }
-          return null;
-        }),
-      );
-      setFiles(
-        checks.filter(
-          (f): f is { key: string; label: string; path: string } => f != null,
-        ),
-      );
-    };
-    loadFiles();
+    if (!job) return;
+    const entries = Object.entries(job.paths || {}).filter(([k, v]) => {
+      if (!v) return false;
+      if (k === 'error' && job.status === 'Succeeded') return false;
+      if (k === 'output' && job.status === 'Running') return false;
+      return true;
+    });
+    setFiles(
+      entries.map(([k, v]) => ({ key: k, label: k, path: v as string })),
+    );
   }, [job]);
 
 

--- a/frontend/src/pages/JobDetail.tsx
+++ b/frontend/src/pages/JobDetail.tsx
@@ -156,6 +156,9 @@ export default function JobDetail() {
       });
       const checks = await Promise.all(
         entries.map(async ([k, v]) => {
+          if (k === 'input') {
+            return { key: k, label: k, path: v as string };
+          }
           let url = v as string;
           if (!url.startsWith('http')) url = `${OpenAPI.BASE}${v}`;
           try {

--- a/frontend/swagger/v1/swagger.json
+++ b/frontend/swagger/v1/swagger.json
@@ -257,7 +257,8 @@
                   "paths": {
                     "input": "/api/v1/jobs/00000000-0000-0000-0000-000000000000/files/input.pdf",
                     "output": "/api/v1/jobs/00000000-0000-0000-0000-000000000000/files/output.json",
-                    "error": "/api/v1/jobs/00000000-0000-0000-0000-000000000000/files/error.txt"
+                    "error": "/api/v1/jobs/00000000-0000-0000-0000-000000000000/files/error.txt",
+                    "markdown": "/api/v1/jobs/00000000-0000-0000-0000-000000000000/files/markdown.md"
                   },
                   "model": "model",
                   "templateToken": "template"
@@ -337,6 +338,76 @@
                   "error": "conflict",
                   "message": "job already in terminal state",
                   "status": "Succeeded"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/markdown": {
+      "post": {
+        "tags": [
+          "Markdown"
+        ],
+        "operationId": "Markdown_Convert",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                }
+              },
+              "encoding": {
+                "file": {
+                  "style": "form"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MarkdownResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Content",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1006,6 +1077,52 @@
   },
   "components": {
     "schemas": {
+      "Box": {
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "x": {
+            "type": "number",
+            "format": "double"
+          },
+          "y": {
+            "type": "number",
+            "format": "double"
+          },
+          "width": {
+            "type": "number",
+            "format": "double"
+          },
+          "height": {
+            "type": "number",
+            "format": "double"
+          },
+          "xNorm": {
+            "type": "number",
+            "format": "double"
+          },
+          "yNorm": {
+            "type": "number",
+            "format": "double"
+          },
+          "widthNorm": {
+            "type": "number",
+            "format": "double"
+          },
+          "heightNorm": {
+            "type": "number",
+            "format": "double"
+          },
+          "text": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
       "CreateModelRequest": {
         "type": "object",
         "properties": {
@@ -1205,6 +1322,30 @@
         "additionalProperties": false,
         "description": "Summary information for a job."
       },
+      "MarkdownResult": {
+        "type": "object",
+        "properties": {
+          "markdown": {
+            "type": "string",
+            "nullable": true
+          },
+          "pages": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PageInfo"
+            },
+            "nullable": true
+          },
+          "boxes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Box"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
       "MetricsInfo": {
         "type": "object",
         "properties": {
@@ -1328,6 +1469,24 @@
         },
         "additionalProperties": false
       },
+      "PageInfo": {
+        "type": "object",
+        "properties": {
+          "number": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "width": {
+            "type": "number",
+            "format": "double"
+          },
+          "height": {
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "additionalProperties": false
+      },
       "PagedJobsResponse": {
         "type": "object",
         "properties": {
@@ -1370,6 +1529,10 @@
             "nullable": true
           },
           "error": {
+            "type": "string",
+            "nullable": true
+          },
+          "markdown": {
             "type": "string",
             "nullable": true
           }

--- a/src/DocflowAi.Net.Api/JobQueue/Data/DefaultJobSeeder.cs
+++ b/src/DocflowAi.Net.Api/JobQueue/Data/DefaultJobSeeder.cs
@@ -61,7 +61,8 @@ public static class DefaultJobSeeder
                         Dir = okDir,
                         Input = Path.Combine(okDir, "input.pdf"),
                         Output = Path.Combine(okDir, "output.json"),
-                        Error = string.Empty
+                        Error = string.Empty,
+                        Markdown = Path.Combine(okDir, "markdown.md")
                     }
                 };
 
@@ -87,7 +88,8 @@ public static class DefaultJobSeeder
                         Dir = errDir,
                         Input = Path.Combine(errDir, "input.png"),
                         Output = string.Empty,
-                        Error = Path.Combine(errDir, "error.txt")
+                        Error = Path.Combine(errDir, "error.txt"),
+                        Markdown = Path.Combine(errDir, "markdown.md")
                     }
                 };
 

--- a/src/DocflowAi.Net.Api/JobQueue/Endpoints/JobEndpoints.cs
+++ b/src/DocflowAi.Net.Api/JobQueue/Endpoints/JobEndpoints.cs
@@ -363,8 +363,12 @@ public static class JobEndpoints
         return builder;
     }
 
-    private static string? ToPublicPath(Guid id, string? path) =>
-        string.IsNullOrEmpty(path) ? null : $"/api/v1/jobs/{id}/files/{Path.GetFileName(path)}";
+    private static string? ToPublicPath(Guid id, string? path)
+    {
+        if (string.IsNullOrEmpty(path)) return null;
+        var full = Path.GetFullPath(path);
+        return File.Exists(full) ? $"/api/v1/jobs/{id}/files/{Path.GetFileName(full)}" : null;
+    }
 
     private static string GetContentType(string fileName) =>
         fileName.EndsWith(".json", StringComparison.OrdinalIgnoreCase) ? "application/json" :

--- a/src/DocflowAi.Net.Api/JobQueue/Models/JobDocument.cs
+++ b/src/DocflowAi.Net.Api/JobQueue/Models/JobDocument.cs
@@ -32,5 +32,6 @@ public class JobDocument
         public string? Input { get; set; }
         public string? Output { get; set; }
         public string? Error { get; set; }
+        public string? Markdown { get; set; }
     }
 }

--- a/src/DocflowAi.Net.Api/JobQueue/Processing/IProcessService.cs
+++ b/src/DocflowAi.Net.Api/JobQueue/Processing/IProcessService.cs
@@ -1,13 +1,13 @@
 namespace DocflowAi.Net.Api.JobQueue.Processing;
 
-public record ProcessInput(Guid JobId, string InputPath, string TemplateToken, string Model);
+public record ProcessInput(Guid JobId, string InputPath, string MarkdownPath, string TemplateToken, string Model);
 public record ProcessResult(bool Success, string OutputJson, string? Markdown, string? ErrorMessage);
 
 public interface IProcessService
 {
     /// <summary>
     /// Executes the internal "process" pipeline for the given job artifacts.
-    /// The service must not mutate job state or write to the filesystem.
+    /// The service may persist intermediate files but must not mutate job state.
     /// </summary>
     /// <param name="input">Paths to job artifacts.</param>
     /// <param name="ct">Cancellation token.</param>

--- a/src/DocflowAi.Net.Api/JobQueue/Processing/IProcessService.cs
+++ b/src/DocflowAi.Net.Api/JobQueue/Processing/IProcessService.cs
@@ -1,7 +1,7 @@
 namespace DocflowAi.Net.Api.JobQueue.Processing;
 
 public record ProcessInput(Guid JobId, string InputPath, string TemplateToken, string Model);
-public record ProcessResult(bool Success, string OutputJson, string? ErrorMessage);
+public record ProcessResult(bool Success, string OutputJson, string? Markdown, string? ErrorMessage);
 
 public interface IProcessService
 {

--- a/src/DocflowAi.Net.Api/JobQueue/Processing/ProcessService.cs
+++ b/src/DocflowAi.Net.Api/JobQueue/Processing/ProcessService.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Text.Json;
+using DocflowAi.Net.Api.JobQueue.Abstractions;
 using DocflowAi.Net.Api.JobQueue.Processing;
 using DocflowAi.Net.Api.Templates.Abstractions;
 using DocflowAi.Net.Application.Abstractions;
@@ -25,6 +26,7 @@ public class ProcessService : IProcessService
     private readonly IMarkdownConverter _converter;
     private readonly ILlamaExtractor _llama;
     private readonly IResolverOrchestrator _resolver;
+    private readonly IFileSystemService _fs;
     private readonly Serilog.ILogger _logger = Log.ForContext<ProcessService>();
     private readonly MarkdownOptions _mdOptions;
 
@@ -33,12 +35,14 @@ public class ProcessService : IProcessService
         IMarkdownConverter converter,
         ILlamaExtractor llama,
         IResolverOrchestrator resolver,
+        IFileSystemService fs,
         IOptions<MarkdownOptions> mdOptions)
     {
         _templates = templates;
         _converter = converter;
         _llama = llama;
         _resolver = resolver;
+        _fs = fs;
         _mdOptions = mdOptions.Value;
     }
 
@@ -67,6 +71,8 @@ public class ProcessService : IProcessService
                 md = await _converter.ConvertImageAsync(fs, _mdOptions, ct);
             }
             mdSw.Stop();
+
+            await _fs.SaveTextAtomic(input.JobId, Path.GetFileName(input.MarkdownPath), md.Markdown);
 
             var llmSw = Stopwatch.StartNew();
             var analysis = await _llama.ExtractAsync(md.Markdown, tpl.Name, tpl.PromptMarkdown ?? string.Empty, fields, ct);

--- a/src/DocflowAi.Net.Api/JobQueue/Processing/ProcessService.cs
+++ b/src/DocflowAi.Net.Api/JobQueue/Processing/ProcessService.cs
@@ -48,7 +48,7 @@ public class ProcessService : IProcessService
         {
             var tpl = _templates.GetByToken(input.TemplateToken);
             if (tpl == null)
-                return new ProcessResult(false, string.Empty, "template not found");
+                return new ProcessResult(false, string.Empty, null, "template not found");
 
             var fields = JsonSerializer.Deserialize<List<FieldSpec>>(tpl.FieldsJson) ?? new();
 
@@ -95,12 +95,12 @@ public class ProcessService : IProcessService
                 }
             };
             var json = JsonSerializer.Serialize(output);
-            return new ProcessResult(true, json, null);
+            return new ProcessResult(true, json, md.Markdown, null);
         }
         catch (Exception ex)
         {
             _logger.Error(ex, "ProcessFailed {JobId}", input.JobId);
-            return new ProcessResult(false, string.Empty, ex.Message);
+            return new ProcessResult(false, string.Empty, null, ex.Message);
         }
     }
 

--- a/src/DocflowAi.Net.Api/JobQueue/Services/JobRunner.cs
+++ b/src/DocflowAi.Net.Api/JobQueue/Services/JobRunner.cs
@@ -79,7 +79,7 @@ public class JobRunner : IJobRunner
                 ProcessResult result;
                 try
                 {
-                      var input = new ProcessInput(jobId, job.Paths.Input!, job.TemplateToken, job.Model);
+                      var input = new ProcessInput(jobId, job.Paths.Input!, job.Paths.Markdown!, job.TemplateToken, job.Model);
                     result = await timeoutPolicy.ExecuteAsync(token => _process.ExecuteAsync(input, token), leaseCts.Token);
                 }
                 catch (OperationCanceledException)
@@ -110,11 +110,6 @@ public class JobRunner : IJobRunner
                 {
                     leaseCts.Cancel();
                     try { await heartbeat; } catch { }
-                }
-
-                if (!string.IsNullOrEmpty(result.Markdown) && job.Paths.Markdown != null)
-                {
-                      await _fs.SaveTextAtomic(jobId, Path.GetFileName(job.Paths.Markdown!), result.Markdown);
                 }
 
                 if (result.Success)

--- a/src/DocflowAi.Net.Api/JobQueue/Services/JobRunner.cs
+++ b/src/DocflowAi.Net.Api/JobQueue/Services/JobRunner.cs
@@ -112,6 +112,11 @@ public class JobRunner : IJobRunner
                     try { await heartbeat; } catch { }
                 }
 
+                if (!string.IsNullOrEmpty(result.Markdown) && job.Paths.Markdown != null)
+                {
+                      await _fs.SaveTextAtomic(jobId, Path.GetFileName(job.Paths.Markdown!), result.Markdown);
+                }
+
                 if (result.Success)
                 {
                       await _fs.SaveTextAtomic(jobId, Path.GetFileName(job.Paths.Output!), result.OutputJson);

--- a/tests/DocflowAi.Net.Api.Tests/AtomicWritesTests.cs
+++ b/tests/DocflowAi.Net.Api.Tests/AtomicWritesTests.cs
@@ -25,7 +25,8 @@ public class AtomicWritesTests : IClassFixture<TempDirFixture>
                 Dir = dir,
                 Input = input,
                 Output = PathHelpers.OutputPath(dataRoot, id),
-                Error = PathHelpers.ErrorPath(dataRoot, id)
+                Error = PathHelpers.ErrorPath(dataRoot, id),
+                Markdown = PathHelpers.MarkdownPath(dataRoot, id)
             }
         };
 

--- a/tests/DocflowAi.Net.Api.Tests/ConcurrencyRunnerTests.cs
+++ b/tests/DocflowAi.Net.Api.Tests/ConcurrencyRunnerTests.cs
@@ -25,7 +25,8 @@ public class ConcurrencyRunnerTests : IClassFixture<TempDirFixture>
                 Dir = dir,
                 Input = input,
                 Output = Path.Combine(dir, "output.json"),
-                Error = Path.Combine(dir, "error.txt")
+                Error = Path.Combine(dir, "error.txt"),
+                Markdown = Path.Combine(dir, "markdown.md")
             },
             CreatedAt = DateTimeOffset.UtcNow,
             UpdatedAt = DateTimeOffset.UtcNow,

--- a/tests/DocflowAi.Net.Api.Tests/Fakes/FakeProcessService.cs
+++ b/tests/DocflowAi.Net.Api.Tests/Fakes/FakeProcessService.cs
@@ -1,4 +1,5 @@
 using DocflowAi.Net.Api.JobQueue.Processing;
+using System.IO;
 
 namespace DocflowAi.Net.Api.Tests.Fakes;
 
@@ -29,6 +30,8 @@ public class FakeProcessService : IProcessService
                 break;
         }
 
+        await File.WriteAllTextAsync(input.MarkdownPath, "# md", ct);
+
         try
         {
             switch (CurrentMode)
@@ -36,7 +39,7 @@ public class FakeProcessService : IProcessService
                 case Mode.Success:
                     return new ProcessResult(true, "{\"ok\":true}", "# md", null);
                 case Mode.Fail:
-                    return new ProcessResult(false, string.Empty, null, "boom");
+                    return new ProcessResult(false, string.Empty, "# md", "boom");
                 case Mode.Slow:
                     await Task.Delay(SlowDelay, ct);
                     return new ProcessResult(true, "{}", "# md", null);

--- a/tests/DocflowAi.Net.Api.Tests/Fakes/FakeProcessService.cs
+++ b/tests/DocflowAi.Net.Api.Tests/Fakes/FakeProcessService.cs
@@ -34,17 +34,17 @@ public class FakeProcessService : IProcessService
             switch (CurrentMode)
             {
                 case Mode.Success:
-                    return new ProcessResult(true, "{\"ok\":true}", null);
+                    return new ProcessResult(true, "{\"ok\":true}", "# md", null);
                 case Mode.Fail:
-                    return new ProcessResult(false, string.Empty, "boom");
+                    return new ProcessResult(false, string.Empty, null, "boom");
                 case Mode.Slow:
                     await Task.Delay(SlowDelay, ct);
-                    return new ProcessResult(true, "{}", null);
+                    return new ProcessResult(true, "{}", "# md", null);
                 case Mode.Cancellable:
                     await Task.Delay(Timeout.InfiniteTimeSpan, ct);
-                    return new ProcessResult(true, "{}", null);
+                    return new ProcessResult(true, "{}", "# md", null);
                 default:
-                    return new ProcessResult(true, "{}", null);
+                    return new ProcessResult(true, "{}", "# md", null);
             }
         }
         finally

--- a/tests/DocflowAi.Net.Api.Tests/GetJobByIdTests.cs
+++ b/tests/DocflowAi.Net.Api.Tests/GetJobByIdTests.cs
@@ -45,7 +45,8 @@ public class GetJobByIdTests : IClassFixture<TempDirFixture>
                 Dir = dir,
                 Input = Path.Combine(dir, "i.pdf"),
                 Output = outputPath,
-                Error = Path.Combine(dir, "e.txt")
+                Error = Path.Combine(dir, "e.txt"),
+                Markdown = Path.Combine(dir, "markdown.md")
             },
             Metrics = new JobDocument.MetricsInfo()
         };
@@ -91,7 +92,7 @@ public class GetJobByIdTests : IClassFixture<TempDirFixture>
             Hash = "h",
             Model = "m",
             TemplateToken = "t",
-            Paths = new JobDocument.PathInfo { Dir = dir, Output = outputPath }
+            Paths = new JobDocument.PathInfo { Dir = dir, Output = outputPath, Markdown = Path.Combine(dir, "markdown.md") }
         };
         store.Create(job);
         uow.SaveChanges();

--- a/tests/DocflowAi.Net.Api.Tests/GetJobByIdTests.cs
+++ b/tests/DocflowAi.Net.Api.Tests/GetJobByIdTests.cs
@@ -58,7 +58,15 @@ public class GetJobByIdTests : IClassFixture<TempDirFixture>
         json.GetProperty("status").GetString().Should().Be("Running");
         json.GetProperty("derivedStatus").GetString().Should().Be("Processing");
         json.GetProperty("progress").GetInt32().Should().Be(42);
-        json.GetProperty("paths").GetProperty("output").GetString().Should().Be($"/api/v1/jobs/{id}/files/o.json");
+        var paths = json.GetProperty("paths");
+        paths.GetProperty("input").ValueKind.Should().Be(JsonValueKind.Null);
+        paths.GetProperty("error").ValueKind.Should().Be(JsonValueKind.Null);
+        paths.GetProperty("markdown").ValueKind.Should().Be(JsonValueKind.Null);
+        paths
+            .GetProperty("output")
+            .GetString()
+            .Should()
+            .Be($"/api/v1/jobs/{id}/files/o.json");
     }
 
     [Fact]

--- a/tests/DocflowAi.Net.Api.Tests/Helpers/DbTestHelper.cs
+++ b/tests/DocflowAi.Net.Api.Tests/Helpers/DbTestHelper.cs
@@ -40,7 +40,7 @@ public static class DbTestHelper
             Hash = faker.Random.Hash(),
             Model = "m",
             TemplateToken = "t",
-            Paths = new JobDocument.PathInfo { Dir = "", Input = "", Output = "", Error = "" },
+            Paths = new JobDocument.PathInfo { Dir = "", Input = "", Output = "", Error = "", Markdown = "" },
             Metrics = new JobDocument.MetricsInfo()
         };
     }

--- a/tests/DocflowAi.Net.Api.Tests/Helpers/PathHelpers.cs
+++ b/tests/DocflowAi.Net.Api.Tests/Helpers/PathHelpers.cs
@@ -10,4 +10,7 @@ public static class PathHelpers
 
     public static string ErrorPath(string dataRoot, Guid jobId)
         => Path.Combine(JobDir(dataRoot, jobId), "error.txt");
+
+    public static string MarkdownPath(string dataRoot, Guid jobId)
+        => Path.Combine(JobDir(dataRoot, jobId), "markdown.md");
 }

--- a/tests/DocflowAi.Net.Api.Tests/JobEndpointsHelpersTests.cs
+++ b/tests/DocflowAi.Net.Api.Tests/JobEndpointsHelpersTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Reflection;
+using System.IO;
 using DocflowAi.Net.Api.JobQueue.Endpoints;
 using FluentAssertions;
 using Xunit;
@@ -17,11 +18,27 @@ public class JobEndpointsHelpersTests
     [Theory]
     [InlineData(null, null)]
     [InlineData("", null)]
-    [InlineData("/tmp/a.txt", "/api/v1/jobs/00000000-0000-0000-0000-000000000000/files/a.txt")]
     public void ToPublicPath_Transforms_Correctly(string? input, string? expected)
     {
         var id = Guid.Empty;
         Invoke<string?>("ToPublicPath", id, input).Should().Be(expected);
+    }
+
+    [Fact]
+    public void ToPublicPath_Transforms_Existing_File()
+    {
+        var id = Guid.Empty;
+        var tmp = Path.GetTempFileName();
+        try
+        {
+            Invoke<string?>("ToPublicPath", id, tmp)
+                .Should()
+                .Be($"/api/v1/jobs/{id}/files/{Path.GetFileName(tmp)}");
+        }
+        finally
+        {
+            File.Delete(tmp);
+        }
     }
 
     [Theory]

--- a/tests/DocflowAi.Net.Api.Tests/ProcessServiceTests.cs
+++ b/tests/DocflowAi.Net.Api.Tests/ProcessServiceTests.cs
@@ -39,6 +39,7 @@ public class ProcessServiceTests
         var json = JsonDocument.Parse(res.OutputJson);
         json.RootElement.GetProperty("fields")[0].GetProperty("key").GetString().Should().Be("f");
         json.RootElement.GetProperty("metrics").GetProperty("total_ms").GetDouble().Should().BeGreaterThan(0);
+        res.Markdown.Should().Be("md");
     }
 
     private sealed class StubRepo : ITemplateRepository

--- a/tests/DocflowAi.Net.Api.Tests/ReschedulerTests.cs
+++ b/tests/DocflowAi.Net.Api.Tests/ReschedulerTests.cs
@@ -28,7 +28,8 @@ public class ReschedulerTests : IClassFixture<TempDirFixture>
                 Dir = dir,
                 Input = input,
                 Output = Path.Combine(dir, "output.json"),
-                Error = Path.Combine(dir, "error.txt")
+                Error = Path.Combine(dir, "error.txt"),
+                Markdown = Path.Combine(dir, "markdown.md")
             },
             CreatedAt = DateTimeOffset.UtcNow,
             UpdatedAt = DateTimeOffset.UtcNow,

--- a/tests/DocflowAi.Net.Api.Tests/RunnerFailureTimeoutCancelTests.cs
+++ b/tests/DocflowAi.Net.Api.Tests/RunnerFailureTimeoutCancelTests.cs
@@ -26,7 +26,8 @@ public class RunnerFailureTimeoutCancelTests : IClassFixture<TempDirFixture>
                 Dir = dir,
                 Input = input,
                 Output = PathHelpers.OutputPath(dataRoot, id),
-                Error = PathHelpers.ErrorPath(dataRoot, id)
+                Error = PathHelpers.ErrorPath(dataRoot, id),
+                Markdown = PathHelpers.MarkdownPath(dataRoot, id)
             }
         };
 

--- a/tests/DocflowAi.Net.Api.Tests/RunnerSuccessTests.cs
+++ b/tests/DocflowAi.Net.Api.Tests/RunnerSuccessTests.cs
@@ -41,7 +41,8 @@ public class RunnerSuccessTests : IClassFixture<TempDirFixture>
                 Dir = dir,
                 Input = inputPath,
                 Output = PathHelpers.OutputPath(factory.DataRootPath, id),
-                Error = PathHelpers.ErrorPath(factory.DataRootPath, id)
+                Error = PathHelpers.ErrorPath(factory.DataRootPath, id),
+                Markdown = PathHelpers.MarkdownPath(factory.DataRootPath, id)
             }
         };
         store.Create(doc);
@@ -56,6 +57,7 @@ public class RunnerSuccessTests : IClassFixture<TempDirFixture>
         job.Progress.Should().Be(100);
         job.Metrics.EndedAt.Should().NotBeNull();
         File.Exists(PathHelpers.OutputPath(factory.DataRootPath, id)).Should().BeTrue();
+        File.ReadAllText(PathHelpers.MarkdownPath(factory.DataRootPath, id)).Should().Contain("md");
         File.Exists(PathHelpers.ErrorPath(factory.DataRootPath, id)).Should().BeFalse();
     }
 }

--- a/tests/DocflowAi.Net.Api.Tests/RunnerTests.cs
+++ b/tests/DocflowAi.Net.Api.Tests/RunnerTests.cs
@@ -28,7 +28,8 @@ public class RunnerTests : IClassFixture<TempDirFixture>
                 Dir = dir,
                 Input = input,
                 Output = Path.Combine(dir, "output.json"),
-                Error = Path.Combine(dir, "error.txt")
+                Error = Path.Combine(dir, "error.txt"),
+                Markdown = Path.Combine(dir, "markdown.md")
             }
         };
 
@@ -38,7 +39,7 @@ public class RunnerTests : IClassFixture<TempDirFixture>
         await using var factory = new TestWebAppFactory(_fx.RootPath)
             .WithWebHostBuilder(b => b.ConfigureServices(s =>
                 s.AddSingleton<IProcessService>(new DelegateProcessService((_, _) =>
-                    Task.FromResult(new ProcessResult(true, "{\"ok\":1}", null))))));
+                    Task.FromResult(new ProcessResult(true, "{\"ok\":1}", null, null))))));
         using var scope = factory.Services.CreateScope();
         var sp = scope.ServiceProvider;
         var store = sp.GetRequiredService<IJobRepository>();
@@ -66,7 +67,7 @@ public class RunnerTests : IClassFixture<TempDirFixture>
         await using var factory = new TestWebAppFactory(_fx.RootPath)
             .WithWebHostBuilder(b => b.ConfigureServices(s =>
                 s.AddSingleton<IProcessService>(new DelegateProcessService((_, _) =>
-                    Task.FromResult(new ProcessResult(false, "", "boom"))))));
+                    Task.FromResult(new ProcessResult(false, "", null, "boom"))))));
         using var scope = factory.Services.CreateScope();
         var sp = scope.ServiceProvider;
         var store = sp.GetRequiredService<IJobRepository>();
@@ -101,7 +102,7 @@ public class RunnerTests : IClassFixture<TempDirFixture>
                 b.ConfigureServices(s => s.AddSingleton<IProcessService>(new DelegateProcessService(async (_, ct) =>
                 {
                     await Task.Delay(TimeSpan.FromSeconds(5), ct);
-                    return new ProcessResult(true, "{}", null);
+                    return new ProcessResult(true, "{}", null, null);
                 })));
             });
         using var scope = factory.Services.CreateScope();
@@ -133,7 +134,7 @@ public class RunnerTests : IClassFixture<TempDirFixture>
                 s.AddSingleton<IProcessService>(new DelegateProcessService(async (_, ct) =>
                 {
                     await Task.Delay(Timeout.Infinite, ct);
-                    return new ProcessResult(true, "{}", null);
+                    return new ProcessResult(true, "{}", null, null);
                 }))));
         using var scope = factory.Services.CreateScope();
         var sp = scope.ServiceProvider;

--- a/tools/DatasetCli/Program.cs
+++ b/tools/DatasetCli/Program.cs
@@ -106,5 +106,5 @@ Console.WriteLine(JsonSerializer.Serialize(summary, options));
 record SubmitResponse(Guid job_id, string status_url, string? dashboard_url);
 
 record MetricsInfo(DateTimeOffset? StartedAt, DateTimeOffset? EndedAt, long? DurationMs);
-record PathInfo(string Dir, string? Input, string? Output, string? Error);
+record PathInfo(string Dir, string? Input, string? Output, string? Error, string? Markdown);
 record JobDetail(Guid Id, string Status, string? DerivedStatus, int Progress, int Attempts, DateTimeOffset CreatedAt, DateTimeOffset UpdatedAt, MetricsInfo Metrics, PathInfo Paths, string? ErrorMessage, string Model, string TemplateToken);


### PR DESCRIPTION
## Summary
- Always show input artifact on job details page
- Avoid erroneous 'Not Found' errors when loading job files
- Add regression test for job detail file list

## Testing
- `rg -n -i 'pytest|:8000|sidecar|MarkitdownException|MARKITDOWN_URL|PY_MARKITDOWN_ENABLED' --glob '!AGENTS.md'`
- `dotnet build -c Release`
- `dotnet test -c Release`
- `npm ci`
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5b037176883258fd9a84ec3f52039