### PR TITLE
Copy RapidOCR models into build output

### DIFF
--- a/src/DocflowAi.Net.Api/DocflowAi.Net.Api.csproj
+++ b/src/DocflowAi.Net.Api/DocflowAi.Net.Api.csproj
@@ -53,6 +53,13 @@
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\markitdownnet\src\RapidOcrNet\models\**\*">
+      <Link>models\%(RecursiveDir)%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </None>
+  </ItemGroup>
   <PropertyGroup>
     <!-- Scegli UNA variante: noavx | avx | avx2 | avx512 -->
     <LlamaCpuVariant>avx2</LlamaCpuVariant>

--- a/src/DocflowAi.Net.Infrastructure/DocflowAi.Net.Infrastructure.csproj
+++ b/src/DocflowAi.Net.Infrastructure/DocflowAi.Net.Infrastructure.csproj
@@ -15,4 +15,10 @@
     <PackageReference Include="LLamaSharp" Version="0.24.0" />
     <PackageReference Include="LLamaSharp.Backend.Cpu" Version="0.24.0" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\markitdownnet\src\RapidOcrNet\models\**\*">
+      <Link>models\%(RecursiveDir)%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- include RapidOCR model files in infrastructure assembly output
- copy RapidOCR models to API publish output to enable Markdown conversion

## Testing
- `dotnet build -c Release`
- `dotnet test -c Release`
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad56eb078c83259b281291a8990286