### PR TITLE
Fix document preview horizontal scrolling

### DIFF
--- a/frontend/src/components/DocumentPreview.test.tsx
+++ b/frontend/src/components/DocumentPreview.test.tsx
@@ -173,6 +173,30 @@ describe('DocumentPreview', () => {
     await waitFor(() => expect(scroll.style.overflowX).toBe('auto'));
   });
 
+  it('expands scroll width when zoomed in', async () => {
+    const { getByTestId } = render(
+      <DocumentPreview
+        docType={sample.docType}
+        srcUrl={sample.srcUrl}
+        pages={sample.pages}
+        currentPage={1}
+        zoom={2}
+        selectedWordIds={new Set()}
+        onWordClick={() => {}}
+        onPageChange={() => {}}
+        onZoomChange={() => {}}
+      />, 
+    );
+    const scroll = getByTestId('preview-scroll');
+    Object.defineProperty(scroll, 'clientWidth', { value: 100, configurable: true });
+    Object.defineProperty(scroll, 'clientHeight', { value: 200, configurable: true });
+    window.dispatchEvent(new Event('resize'));
+    await waitFor(() => {
+      const outer = getByTestId('preview-outer');
+      expect(outer.style.width).toBe('200px');
+    });
+  });
+
   it('centers on selected word', async () => {
     const { getByTestId, rerender } = render(
       <DocumentPreview

--- a/frontend/src/components/DocumentPreview.tsx
+++ b/frontend/src/components/DocumentPreview.tsx
@@ -176,51 +176,56 @@ export default function DocumentPreview({
         }}
       >
         <div
-          data-testid="preview-inner"
-          style={{
-            transform: `scale(${scale})`,
-            transformOrigin: 'top left',
-            width: page.width,
-            height: page.height,
-            position: 'relative',
-          }}
+          data-testid="preview-outer"
+          style={{ width: page.width * scale, height: page.height * scale }}
         >
-          {docType === 'pdf' ? (
-            <canvas
-              data-testid="pdf-canvas"
-              ref={canvasRef}
-              style={{ display: 'block' }}
-            />
-          ) : (
-            <img
-              ref={imgRef}
-              data-testid="img-preview"
-              src={srcUrl}
-              alt="document"
-              style={{ display: 'block', width: page.width, height: page.height }}
-            />
-          )}
-          <svg
-            width={page.width}
-            height={page.height}
-            style={{ position: 'absolute', top: 0, left: 0 }}
+          <div
+            data-testid="preview-inner"
+            style={{
+              transform: `scale(${scale})`,
+              transformOrigin: 'top left',
+              width: page.width,
+              height: page.height,
+              position: 'relative',
+            }}
           >
-            {words.map((w) => (
-              <rect
-                key={w.id}
-                data-testid={`bbox-${w.id}`}
-                data-word-id={w.id}
-                x={w.bbox.x}
-                y={w.bbox.y}
-                width={w.bbox.width}
-                height={w.bbox.height}
-                fill={selectedWordIds.has(w.id) ? 'rgba(0,123,255,0.3)' : 'transparent'}
-                stroke={selectedWordIds.has(w.id) ? '#1890ff' : 'rgba(0,0,0,0.2)'}
-                strokeWidth={selectedWordIds.has(w.id) ? 2 : 1}
-                onClick={() => onWordClick(w.id)}
+            {docType === 'pdf' ? (
+              <canvas
+                data-testid="pdf-canvas"
+                ref={canvasRef}
+                style={{ display: 'block' }}
               />
-            ))}
-          </svg>
+            ) : (
+              <img
+                ref={imgRef}
+                data-testid="img-preview"
+                src={srcUrl}
+                alt="document"
+                style={{ display: 'block', width: page.width, height: page.height }}
+              />
+            )}
+            <svg
+              width={page.width}
+              height={page.height}
+              style={{ position: 'absolute', top: 0, left: 0 }}
+            >
+              {words.map((w) => (
+                <rect
+                  key={w.id}
+                  data-testid={`bbox-${w.id}`}
+                  data-word-id={w.id}
+                  x={w.bbox.x}
+                  y={w.bbox.y}
+                  width={w.bbox.width}
+                  height={w.bbox.height}
+                  fill={selectedWordIds.has(w.id) ? 'rgba(0,123,255,0.3)' : 'transparent'}
+                  stroke={selectedWordIds.has(w.id) ? '#1890ff' : 'rgba(0,0,0,0.2)'}
+                  strokeWidth={selectedWordIds.has(w.id) ? 2 : 1}
+                  onClick={() => onWordClick(w.id)}
+                />
+              ))}
+            </svg>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- allow horizontal scrolling by expanding preview area when zoomed
- add regression test for scroll width

## Testing
- `npm ci`
- `npm test -- --run`
- `npm run build`
- `dotnet build -c Release`
- `dotnet test -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68b1739e1bc483259e42a5989b890adc